### PR TITLE
Fix: Add missing build script for api service

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,13 +5,15 @@
     "@types/jest": "^29.5.12",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
+    "@nestjs/cli": "^10.0.0",
     "jest": "^29.7.0",
     "prisma": "^6.10.0",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "nest build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}


### PR DESCRIPTION
The api service was failing to build due to a missing "build" script in `api/package.json`.

This commit fixes the issue by:
- Adding `@nestjs/cli` to `devDependencies` in `api/package.json`.
- Adding a "build" script to `api/package.json` that runs `nest build`.

This resolves the "Missing script: build" error when running `docker-compose up --build`.