### PR TITLE
Fix: Add Dockerfile for client service and update docker-compose.yml

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build the Vite application
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json (or yarn.lock or pnpm-lock.yaml)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Stage 2: Serve the application with Nginx
+FROM nginx:stable-alpine AS production
+
+# Copy built assets from the build stage
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Copy the Nginx configuration file
+# This file will be created in the next step of the plan
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 3000 (as the client runs on 3000)
+EXPOSE 3000
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 3000;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Optional: Add error pages
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
         condition: service_healthy
     environment:
       - VITE_API_URL=http://localhost:3001 # Changed to VITE_ and confirmed URL for browser access
-    volumes:
-      - ./client/src:/app/src
-      - ./client/public:/app/public
     healthcheck: # Added healthcheck for Client
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s


### PR DESCRIPTION
This commit introduces a Dockerfile for the 'client' service and an accompanying Nginx configuration to enable successful containerization and serving of the Vite-based frontend application.

The 'client' service was previously failing to build due to a missing Dockerfile.

Changes include:
- Added `client/Dockerfile`: A multi-stage Dockerfile that builds the Vite application using a Node.js image and serves the static assets using an Nginx image.
- Added `client/nginx.conf`: Configures Nginx to serve the SPA, including a `try_files` directive to route all paths to `index.html`.
- Modified `docker-compose.yml`: Removed the development-specific `volumes` from the `client` service definition. This ensures that the production build served by Nginx uses the assets baked into the image.

With these changes, the `client` service now builds correctly when running `docker-compose up --build` and serves the application on port 3000.