### PR TITLE
Fix: Ensure navigation bar is visible after login and provide logout …

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -9,6 +9,7 @@ import BoardPage from '../pages/BoardPage';
 import LandingPage from '../pages/LandingPage'; // Import LandingPage
 import NotFoundPage from '../pages/NotFoundPage'; // Import NotFoundPage
 import { useAuth } from './auth/AuthContext'; // Import the real useAuth
+import Header from '../widgets/Header/Header';
 
 const App: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth(); // Use real useAuth, include isLoading
@@ -20,10 +21,7 @@ const App: React.FC = () => {
 
   return (
     <Router>
-      <nav>
-        <Link to="/">Home</Link> | <Link to="/dashboard">Dashboard</Link>
-      </nav>
-
+      <Header />
       <Routes>
         {/* Root route: Landing page for unauthenticated, redirect to dashboard for authenticated */}
         <Route path="/" element={isAuthenticated ? <Navigate to="/dashboard" /> : <LandingPage />} />


### PR DESCRIPTION
…capability.

The main navigation bar, including the logout button and user-specific links, was not visible after you logged in because the `Header` component was not being rendered. Additionally, a basic navigation element in `App.tsx` was redundant.

This commit addresses the issue by:
1. Removing the basic navigation element from `App.tsx`.
2. Integrating the `Header` component into `App.tsx` so it is displayed consistently across all pages.

This ensures that you have access to navigation links and the logout functionality after logging in.