### PR TITLE
Fix: Remove unused Link import from App.tsx

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "socket.io-client": "^4.0.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.25.0",
+        "@eslint/js": "^9.29.0",
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "socket.io-client": "^4.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.25.0",
+    "@eslint/js": "^9.29.0",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.0",

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -1,7 +1,7 @@
 // Example in App.tsx using react-router-dom
 import React from 'react';
 import './styles/global.css';
-import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from '../pages/LoginPage'; // Assuming LoginPage exists
 import RegistrationPage from '../pages/RegistrationPage'; // Assuming RegistrationPage exists
 import DashboardPage from '../pages/DashboardPage';


### PR DESCRIPTION
The 'Link' component was imported in 'client/src/app/App.tsx' but was not used, causing a TypeScript build error (TS6133). This commit removes the unused import.