### PR TITLE
Fix: Use cuid() instead of cuid2() in Prisma schema

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 }
 
 model User {
-  id            String   @id @default(cuid2())
+  id            String   @id @default(cuid())
   email         String   @unique
   name          String?
   password      String
@@ -40,7 +40,7 @@ model Project {
 }
 
 model Column {
-  id        String   @id @default(cuid2())
+  id        String   @id @default(cuid())
   name      String
   position  Int
   projectId Int
@@ -54,7 +54,7 @@ model Column {
 }
 
 model Task {
-  id              String    @id @default(cuid2())
+  id              String    @id @default(cuid())
   humanReadableId String    @unique
   taskNumber      Int
   title           String
@@ -81,7 +81,7 @@ model Task {
 }
 
 model Comment {
-  id        String   @id @default(cuid2())
+  id        String   @id @default(cuid())
   text      String
   taskId    String
   authorId  String?
@@ -94,7 +94,7 @@ model Comment {
 }
 
 model Notification {
-  id          String   @id @default(cuid2())
+  id          String   @id @default(cuid())
   text        String
   sourceUrl   String?
   isRead      Boolean  @default(false)


### PR DESCRIPTION
The Prisma schema was using `@default(cuid2())` for ID generation, which caused the `npx prisma generate` command to fail with an "Unknown function" error.

This commit changes all instances of `@default(cuid2())` to the standard `@default(cuid())` in `api/prisma/schema.prisma`. This resolves the build failure during the `prisma generate` step.

The Prisma CLI version (5.17.0) in use supports `cuid()` and this change allows the schema to be correctly processed.