### PR TITLE
Fix: Correct import path for GetUser decorator in CommentsController

### DIFF
--- a/api/src/comments/comments.controller.ts
+++ b/api/src/comments/comments.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Body, Get, Param, UseGuards, Req, ParseUUIDPipe, Http
 import { CommentsService } from './comments.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { User as CurrentUser } from '../auth/decorators/user.decorator'; // Assuming you have a @User decorator
+import { GetUser as CurrentUser } from '../auth/decorators/get-user.decorator'; // Assuming you have a @User decorator
 import { User } from '@prisma/client';
 
 @UseGuards(JwtAuthGuard)


### PR DESCRIPTION
The API build was failing due to an incorrect import path for the user decorator in `api/src/comments/comments.controller.ts`. The controller was attempting to import from `../auth/decorators/user.decorator.ts`, which does not exist.

This commit corrects the import path to `../auth/decorators/get-user.decorator.ts` and updates the named import to `GetUser`, which is the actual exported member from the decorator file.

The alias `CurrentUser` remains the same.

The `api` service now builds successfully.