### PR TITLE
Fix: Resolve KNEX_CONNECTION dependency issue in ProjectsModule

### DIFF
--- a/api/src/knex/knex.module.ts
+++ b/api/src/knex/knex.module.ts
@@ -1,4 +1,39 @@
-import { Module } from '@nestjs/common';
+import { Module, Global } from '@nestjs/common';
+import { KNEX_CONNECTION } from './knex.constants';
+import knex from 'knex'; // Import the knex function
+import knexfile from '../../knexfile'; // Import knexfile configuration
 
-@Module({})
+// Determine the environment based on NODE_ENV or default to 'development'
+const environment = process.env.NODE_ENV || 'development';
+const knexConfig = knexfile[environment];
+
+if (!knexConfig) {
+  throw new Error(`Knex configuration for environment '${environment}' not found in knexfile.js`);
+}
+
+const knexProvider = {
+  provide: KNEX_CONNECTION,
+  useFactory: async () => {
+    const db = knex(knexConfig); // Create knex instance
+
+    // Optional: Test the connection
+    try {
+      await db.raw('select 1+1 as result');
+      console.log('Successfully connected to the database using Knex.');
+    } catch (error) {
+      console.error('Failed to connect to the database using Knex:', error);
+      // Depending on the desired behavior, you might want to throw the error
+      // or handle it in a way that allows the application to start if the DB is optional.
+      // For now, we'll rethrow to make it clear if connection fails.
+      throw error;
+    }
+    return db;
+  },
+};
+
+@Global() // Make the module global so Knex_CONNECTION can be injected anywhere
+@Module({
+  providers: [knexProvider],
+  exports: [knexProvider], // Export the provider
+})
 export class KnexModule {}

--- a/api/src/projects/projects.module.ts
+++ b/api/src/projects/projects.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { ProjectsController } from './projects.controller';
-// import { PrismaModule } from '../prisma/prisma.module'; // PrismaModule removed
+import { KnexModule } from '../knex/knex.module'; // Import KnexModule
 
 @Module({
-  imports: [], // PrismaModule removed
+  imports: [KnexModule], // Add KnexModule to imports
   controllers: [ProjectsController],
   providers: [ProjectsService],
-  exports: [ProjectsService], // Export if other modules will use it
+  exports: [ProjectsService],
 })
 export class ProjectsModule {}


### PR DESCRIPTION
The api service was failing to start due to an unresolved dependency for KNEX_CONNECTION in the ProjectsService.

This commit addresses the issue by:
1. Defining a `KNEX_CONNECTION` constant in `api/src/knex/knex.constants.ts`.
2. Creating a `KnexModule` in `api/src/knex/knex.module.ts`. This module sets up a Knex instance based on `knexfile.js` and provides it using the `KNEX_CONNECTION` token. The module is marked as global.
3. Importing `KnexModule` into `api/src/projects/projects.module.ts`, making the Knex provider available to `ProjectsService`.

These changes ensure that the Knex instance is correctly injected into ProjectsService, resolving the startup error. Docker testing was attempted but blocked by environment permissions.