### PR TITLE
Fix: Copy knexfile.js to production Docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,6 +25,7 @@ COPY package*.json ./
 RUN npm install --omit=dev
 
 COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/knexfile.js ./knexfile.js
 
 EXPOSE 3000
 


### PR DESCRIPTION
The api service was failing to start because knexfile.js was not found. This was due to the knexfile.js not being copied into the final production stage of the Docker build.

This commit updates the api/Dockerfile to include the following instruction in the production stage: COPY --from=builder /usr/src/app/knexfile.js ./knexfile.js

This ensures that knexfile.js is available at the expected location (/usr/src/app/knexfile.js) when the application starts.