### PR TITLE
Fix: Ensure consistent date handling for comments

### DIFF
--- a/client/src/features/Comments/ui/CommentItem.tsx
+++ b/client/src/features/Comments/ui/CommentItem.tsx
@@ -15,14 +15,7 @@ const CommentItem: React.FC<CommentItemProps> = ({ comment }) => {
       </div>
       <p className={styles.commentText}>{comment.text}</p>
       <div className={styles.commentTimestamp}>
-        {(() => {
-          const date = new Date(comment.createdAt);
-          if (isNaN(date.getTime())) {
-            // console.warn('Invalid createdAt value received:', comment.createdAt); // Optional: uncomment for local debugging
-            return 'Date unavailable';
-          }
-          return date.toLocaleString();
-        })()}
+        {comment.createdAt.toLocaleString()}
       </div>
     </div>
   );

--- a/client/src/shared/api/taskService.ts
+++ b/client/src/shared/api/taskService.ts
@@ -15,6 +15,15 @@ export interface MoveTaskDto {
   // oldColumnId?: string; // Backend might not need this if it re-calculates based on task's current state
 }
 
+// Helper function to transform API comment DTO to client-side DTO
+const transformCommentDto = (apiComment: ApiCommentDto): CommentDto => {
+  return {
+    ...apiComment,
+    createdAt: new Date(apiComment.createdAt),
+    updatedAt: new Date(apiComment.updatedAt),
+  };
+};
+
 export const taskService = {
   createTask: async (data: CreateTaskDto): Promise<TaskDto> => {
     const response = await apiClient.post<TaskDto>('/tasks', data);
@@ -28,23 +37,13 @@ export const taskService = {
   // Add other task-related API calls here if needed (e.g., updateTask, getTaskById)
 
   getTaskComments: async (taskId: string): Promise<CommentDto[]> => {
-    const response = await apiClient.get<CommentDto[]>(`/tasks/${taskId}/comments`);
-    // Transform date strings to Date objects
-    return response.data.map(comment => ({
-      ...comment,
-      createdAt: new Date(comment.createdAt),
-      updatedAt: new Date(comment.updatedAt),
-    }));
+    const response = await apiClient.get<ApiCommentDto[]>(`/tasks/${taskId}/comments`);
+    return response.data.map(transformCommentDto);
   },
 
   addTaskComment: async (taskId: string, data: CreateCommentPayloadDto): Promise<CommentDto> => {
-    const response = await apiClient.post<CommentDto>(`/tasks/${taskId}/comments`, data);
-    // Transform date strings to Date objects
-    return {
-      ...response.data,
-      createdAt: new Date(response.data.createdAt),
-      updatedAt: new Date(response.data.updatedAt),
-    };
+    const response = await apiClient.post<ApiCommentDto>(`/tasks/${taskId}/comments`, data);
+    return transformCommentDto(response.data);
   },
 };
 
@@ -62,6 +61,17 @@ export interface CommentDto {
   authorId: string | null;
   createdAt: Date;
   updatedAt: Date;
+  author?: CommentAuthorDto | null;
+}
+
+// DTO for API response before transformation
+export interface ApiCommentDto {
+  id: string;
+  text: string;
+  taskId: string;
+  authorId: string | null;
+  createdAt: string; // Dates are strings from the API
+  updatedAt: string; // Dates are strings from the API
   author?: CommentAuthorDto | null;
 }
 

--- a/client/src/shared/api/taskService.ts
+++ b/client/src/shared/api/taskService.ts
@@ -29,12 +29,22 @@ export const taskService = {
 
   getTaskComments: async (taskId: string): Promise<CommentDto[]> => {
     const response = await apiClient.get<CommentDto[]>(`/tasks/${taskId}/comments`);
-    return response.data;
+    // Transform date strings to Date objects
+    return response.data.map(comment => ({
+      ...comment,
+      createdAt: new Date(comment.createdAt),
+      updatedAt: new Date(comment.updatedAt),
+    }));
   },
 
   addTaskComment: async (taskId: string, data: CreateCommentPayloadDto): Promise<CommentDto> => {
     const response = await apiClient.post<CommentDto>(`/tasks/${taskId}/comments`, data);
-    return response.data;
+    // Transform date strings to Date objects
+    return {
+      ...response.data,
+      createdAt: new Date(response.data.createdAt),
+      updatedAt: new Date(response.data.updatedAt),
+    };
   },
 };
 
@@ -50,8 +60,8 @@ export interface CommentDto {
   text: string;
   taskId: string;
   authorId: string | null;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
   author?: CommentAuthorDto | null;
 }
 


### PR DESCRIPTION
Previously, comment creation and update dates were sometimes displayed as 'Date unavailable'. This was due to a mismatch in how dates were handled between the backend and frontend.

This commit addresses the issue by:
- Changing the `CommentDto` on the client-side to expect `Date` objects for `createdAt` and `updatedAt` fields.
- Updating the `taskService` to transform date strings received from the API into `Date` objects.
- Removing redundant date parsing logic in the `CommentItem` component, as it now receives `Date` objects directly.

These changes ensure that dates are handled consistently as `Date` objects throughout the client-side comment feature, preventing the 'Date unavailable' error and correctly displaying comment timestamps.