### PR TITLE
Fix: Ensure correct date display for comments received via WebSocket

### DIFF
--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
@@ -47,9 +47,14 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
     const handleCommentCreated = (newComment: CommentDto) => {
       console.log('comment:created event received in TaskDetailModal', newComment);
       if (newComment.taskId === task.id) {
+        const transformedComment = {
+          ...newComment,
+          createdAt: new Date(newComment.createdAt),
+          updatedAt: new Date(newComment.updatedAt),
+        };
         setComments(prevComments => {
-          if (prevComments.find(c => c.id === newComment.id)) return prevComments;
-          return [...prevComments, newComment].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+          if (prevComments.find(c => c.id === transformedComment.id)) return prevComments;
+          return [...prevComments, transformedComment].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
         });
       }
     };


### PR DESCRIPTION
The `createdAt` and `updatedAt` fields for comments received via WebSocket events were not being explicitly converted from strings to Date objects in the `TaskDetailModal.tsx` component. This could lead to "Date unavailable" or incorrect date formatting when such comments were displayed.

This commit modifies the `handleCommentCreated` function in `TaskDetailModal.tsx` to transform the `createdAt` and `updatedAt` fields of incoming WebSocket comment data into `Date` objects before updating the component's state. This ensures consistency with the date handling for comments fetched via direct API calls.

I recommend you manually verify that dates for new comments (both self-added and those received via WebSocket) are displayed correctly after this change.