### PR TITLE
Refactor project list to table view

### DIFF
--- a/client/src/pages/DashboardPage.module.css
+++ b/client/src/pages/DashboardPage.module.css
@@ -1,0 +1,30 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+.table th {
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+.table tbody tr:hover {
+  background-color: #f5f5f5;
+}
+
+.link a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.link a:hover {
+  text-decoration: underline;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom'; // Assuming react-router-dom is used
 import { projectService } from '../shared/api/projectService'; // Adjust path as needed
 import type { ProjectDto, CreateProjectDto } from '../shared/api/projectService';
+import styles from './DashboardPage.module.css';
 
 const DashboardPage: React.FC = () => {
   const [projects, setProjects] = useState<ProjectDto[]>([]);
@@ -99,15 +100,26 @@ const DashboardPage: React.FC = () => {
       {projects.length === 0 ? (
         <p>No projects yet. Create one to get started!</p>
       ) : (
-        <ul>
-          {projects.map((project) => (
-            <li key={project.id}>
-              <Link to={`/projects/${project.id}`}>
-                {project.name} ({project.prefix})
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Project Name</th>
+              <th>Prefix</th>
+              <th>Link</th>
+            </tr>
+          </thead>
+          <tbody>
+            {projects.map((project) => (
+              <tr key={project.id}>
+                <td>{project.name}</td>
+                <td>{project.prefix}</td>
+                <td className={styles.link}>
+                  <Link to={`/projects/${project.id}`}>View Board</Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </div>
   );


### PR DESCRIPTION
I replaced the unordered list display of projects on the DashboardPage with a styled table. This provides a more structured and modern presentation of project information.

Changes include:
- Modified `DashboardPage.tsx` to use `<table>` elements for project display.
- Added headers for "Project Name", "Prefix", and "Link".
- Created `DashboardPage.module.css` for table styling, including borders, padding, and row hover effects.