### PR TITLE
Fix: Ensure correct date display in comments

### DIFF
--- a/client/src/shared/api/taskService.ts
+++ b/client/src/shared/api/taskService.ts
@@ -18,9 +18,13 @@ export interface MoveTaskDto {
 // Helper function to transform API comment DTO to client-side DTO
 export const transformCommentDto = (apiComment: ApiCommentDto): CommentDto => {
   return {
-    ...apiComment,
-    createdAt: new Date(apiComment.createdAt),
-    updatedAt: new Date(apiComment.updatedAt),
+    id: apiComment.id,
+    text: apiComment.text,
+    taskId: apiComment.task_id,
+    authorId: apiComment.author_id,
+    createdAt: new Date(apiComment.created_at),
+    updatedAt: new Date(apiComment.updated_at),
+    author: apiComment.author,
   };
 };
 
@@ -68,11 +72,11 @@ export interface CommentDto {
 export interface ApiCommentDto {
   id: string;
   text: string;
-  taskId: string;
-  authorId: string | null;
-  createdAt: string; // Dates are strings from the API
-  updatedAt: string; // Dates are strings from the API
-  author?: CommentAuthorDto | null;
+  task_id: string;
+  author_id: string | null;
+  created_at: string; // Dates are strings from the API
+  updated_at: string; // Dates are strings from the API
+  author?: CommentAuthorDto | null; // Assuming CommentAuthorDto is already correct or will be handled separately
 }
 
 export interface CreateCommentPayloadDto {


### PR DESCRIPTION
The backend API provides comment data in snake_case (e.g., created_at, task_id), while your frontend components expect camelCase (e.g., createdAt, taskId). This mismatch caused 'date unavailable' to be displayed or TypeError when trying to access 'comment.createdAt.toLocaleString()'.

This commit introduces the following changes:

1.  Updated `ApiCommentDto` in `taskService.ts` to accurately reflect the snake_case structure of the raw API response for comments (e.g., `created_at`, `task_id`).
2.  Enhanced the `transformCommentDto` function in `taskService.ts` to:
    - Convert `created_at` (string) to `createdAt` (Date object).
    - Convert `updated_at` (string) to `updatedAt` (Date object).
    - Transform `task_id` to `taskId`.
    - Transform `author_id` to `authorId`.
3.  Verified that `CommentDto` uses camelCase and the correct types, and `CommentItem.tsx` correctly uses `comment.createdAt.toLocaleString()`.

This systemic fix at the API client layer ensures that the rest of your application consistently works with camelCase comment objects and that dates are correctly processed and displayed.