### PR TITLE
Fix: Correct property access for comment task ID in TaskDetailModal

### DIFF
--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
@@ -47,7 +47,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
 
     const handleCommentCreated = (newComment: ApiCommentDto) => {
       console.log('comment:created event received in TaskDetailModal', newComment);
-      if (newComment.taskId === task.id) {
+      if (newComment.task_id === task.id) {
         const commentToDisplay = transformCommentDto(newComment);
         setComments(prevComments => {
           if (prevComments.find(c => c.id === commentToDisplay.id)) return prevComments;


### PR DESCRIPTION
The WebSocket event for a new comment (`comment:created`) provides an `ApiCommentDto` object where the task identifier is `task_id`. The `TaskDetailModal` component was incorrectly trying to access `taskId`.

This commit changes `newComment.taskId` to `newComment.task_id` in the `handleCommentCreated` function within
`client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx` to resolve the TypeScript error (TS2551) and ensure correct runtime behavior.