### PR TITLE
Refactor: Standardize project and task creation modals

### DIFF
--- a/client/src/pages/BoardPage.module.css
+++ b/client/src/pages/BoardPage.module.css
@@ -1,0 +1,47 @@
+/* Styles for the modal form elements in BoardPage */
+.formInput,
+.formTextarea {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+  border: 1px solid #ccc; /* Added some default border */
+  border-radius: 4px; /* Added some default border-radius */
+}
+
+.formTextarea {
+  min-height: 80px;
+  resize: vertical; /* Allow vertical resizing */
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.button {
+  padding: 8px 15px;
+  border-radius: 4px; /* Added default border-radius */
+  border: 1px solid transparent; /* Base for button */
+  cursor: pointer;
+}
+
+.buttonPrimary {
+  background-color: #007bff; /* Example primary color */
+  color: white;
+  border-color: #007bff;
+}
+
+.buttonPrimary:disabled {
+  background-color: #007bff;
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.buttonSecondary {
+  background-color: #6c757d; /* Example secondary/cancel color */
+  color: white;
+  border-color: #6c757d;
+}

--- a/client/src/pages/BoardPage.tsx
+++ b/client/src/pages/BoardPage.tsx
@@ -20,6 +20,7 @@ import { taskService } from '../shared/api/taskService';
 import type { CreateTaskDto } from '../shared/api/taskService';
 import { socket, joinProjectRoom, leaveProjectRoom } from '../shared/lib/socket';
 import { Modal } from '../shared/ui/Modal'; // Import the new Modal
+import styles from './BoardPage.module.css'; // Import css modules
 import ColumnLane from '../features/ColumnLane/ColumnLane'; // Import ColumnLane
 import { ManageProjectMembersModal } from '../features/ProjectMembers'; // Import ManageProjectMembersModal
 import { TaskDetailModal } from '../features/TaskDetailModal'; // Import TaskDetailModal
@@ -385,7 +386,7 @@ const BoardPage: React.FC = () => {
                     value={newTaskTitle}
                     onChange={(e) => setNewTaskTitle(e.target.value)}
                     required
-                    style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+              className={styles.formInput}
                   />
                 </div>
                 <div>
@@ -394,18 +395,22 @@ const BoardPage: React.FC = () => {
                     id="taskDescription"
                     value={newTaskDescription}
                     onChange={(e) => setNewTaskDescription(e.target.value)}
-                    style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px', minHeight: '80px' }}
+              className={styles.formTextarea}
                   />
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
+          <div className={styles.formActions}>
                   <button
                     type="button"
                     onClick={() => setIsAddTaskModalOpen(false)}
-                    style={{ padding: '8px 15px' }}
+              className={`${styles.button} ${styles.buttonSecondary}`}
                   >
                     Cancel
                   </button>
-                  <button type="submit" disabled={isCreatingTask} style={{ padding: '8px 15px' }}>
+            <button
+              type="submit"
+              disabled={isCreatingTask}
+              className={`${styles.button} ${styles.buttonPrimary}`}
+            >
                     {isCreatingTask ? 'Creating...' : 'Create Task'}
                   </button>
                 </div>

--- a/client/src/pages/BoardPage.tsx
+++ b/client/src/pages/BoardPage.tsx
@@ -19,6 +19,7 @@ import type { ProjectDto as FullProjectDto, ColumnDto as ProjectColumnDto, TaskD
 import { taskService } from '../shared/api/taskService';
 import type { CreateTaskDto } from '../shared/api/taskService';
 import { socket, joinProjectRoom, leaveProjectRoom } from '../shared/lib/socket';
+import { Modal } from '../shared/ui/Modal'; // Import the new Modal
 import ColumnLane from '../features/ColumnLane/ColumnLane'; // Import ColumnLane
 import { ManageProjectMembersModal } from '../features/ProjectMembers'; // Import ManageProjectMembersModal
 import { TaskDetailModal } from '../features/TaskDetailModal'; // Import TaskDetailModal
@@ -362,28 +363,58 @@ const BoardPage: React.FC = () => {
               Manage Members
             </button>
           </div>
-          {isAddTaskModalOpen && selectedColumnId && (
-            <div className="modal"> {/* Basic modal styling needed */}
+          {selectedColumnId && ( // Keep selectedColumnId check if it ensures boardData.columns.find is safe
+            <Modal
+              isOpen={isAddTaskModalOpen}
+              onClose={() => {
+                setIsAddTaskModalOpen(false);
+                // Optionally reset form fields here if not done elsewhere
+                // setNewTaskTitle('');
+                // setNewTaskDescription('');
+                // setSelectedColumnId(null); // This might be needed if modal can open before selectedColumnId is ready
+              }}
+              title={`Add New Task to ${boardData?.columns.find(c => c.id === selectedColumnId)?.name || 'Column'}`}
+            >
               <form onSubmit={handleCreateTask}>
-              <h2>Add New Task to {boardData.columns.find(c => c.id === selectedColumnId)?.name}</h2>
-              <div>
-                <label htmlFor="taskTitle">Task Title:</label>
-                <input id="taskTitle" type="text" value={newTaskTitle} onChange={(e) => setNewTaskTitle(e.target.value)} required />
-              </div>
-              <div>
-                <label htmlFor="taskDescription">Description (Optional):</label>
-                <textarea id="taskDescription" value={newTaskDescription} onChange={(e) => setNewTaskDescription(e.target.value)} />
-              </div>
-              <button type="submit" disabled={isCreatingTask}>
-                {isCreatingTask ? 'Creating...' : 'Create Task'}
-              </button>
-              <button type="button" onClick={() => setIsAddTaskModalOpen(false)}>Cancel</button>
-            </form>
-          </div>
-        )}
-        <div style={{ display: 'flex', gap: '16px', overflowX: 'auto', padding: '10px', minHeight: 'calc(100vh - 100px)' }}>
-          {boardData.columns.map((column) => (
-            <ColumnLane key={column.id} column={column} onAddTask={openAddTaskModal} onTaskClick={handleTaskClick} />
+                {/* The h2 title is removed as it's now a prop of Modal */}
+                <div>
+                  <label htmlFor="taskTitle">Task Title:</label>
+                  <input
+                    id="taskTitle"
+                    type="text"
+                    value={newTaskTitle}
+                    onChange={(e) => setNewTaskTitle(e.target.value)}
+                    required
+                    style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="taskDescription">Description (Optional):</label>
+                  <textarea
+                    id="taskDescription"
+                    value={newTaskDescription}
+                    onChange={(e) => setNewTaskDescription(e.target.value)}
+                    style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px', minHeight: '80px' }}
+                  />
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
+                  <button
+                    type="button"
+                    onClick={() => setIsAddTaskModalOpen(false)}
+                    style={{ padding: '8px 15px' }}
+                  >
+                    Cancel
+                  </button>
+                  <button type="submit" disabled={isCreatingTask} style={{ padding: '8px 15px' }}>
+                    {isCreatingTask ? 'Creating...' : 'Create Task'}
+                  </button>
+                </div>
+              </form>
+            </Modal>
+          )}
+          <div style={{ display: 'flex', gap: '16px', overflowX: 'auto', padding: '10px', minHeight: 'calc(100vh - 100px)' }}>
+            {boardData.columns.map((column) => (
+              <ColumnLane key={column.id} column={column} onAddTask={openAddTaskModal} onTaskClick={handleTaskClick} />
           ))}
         </div>
       </div>

--- a/client/src/pages/DashboardPage.module.css
+++ b/client/src/pages/DashboardPage.module.css
@@ -31,3 +31,45 @@
 .link a:hover {
   text-decoration: underline;
 }
+
+/* Styles for the modal form elements */
+.formInput {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+  border: 1px solid #ccc; /* Added some default border */
+  border-radius: 4px; /* Added some default border-radius */
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.button {
+  padding: 8px 15px;
+  border-radius: 4px; /* Added default border-radius */
+  border: 1px solid transparent; /* Base for button */
+  cursor: pointer;
+}
+
+.buttonPrimary {
+  background-color: #007bff; /* Example primary color */
+  color: white;
+  border-color: #007bff;
+}
+
+.buttonPrimary:disabled {
+  background-color: #007bff;
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.buttonSecondary {
+  background-color: #6c757d; /* Example secondary/cancel color */
+  color: white;
+  border-color: #6c757d;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom'; // Assuming react-router-dom is used
 import { projectService } from '../shared/api/projectService'; // Adjust path as needed
 import type { ProjectDto, CreateProjectDto } from '../shared/api/projectService';
+import { Modal } from '../shared/ui/Modal';
 import styles from './DashboardPage.module.css';
 
 const DashboardPage: React.FC = () => {
@@ -64,38 +65,46 @@ const DashboardPage: React.FC = () => {
       <h1>My Projects</h1>
       <button onClick={() => setIsModalOpen(true)}>+ Create New Project</button>
 
-      {isModalOpen && (
-        <div className="modal"> {/* Basic modal styling needed */}
-          <form onSubmit={handleCreateProject}>
-            <h2>Create New Project</h2>
-            <div>
-              <label htmlFor="projectName">Project Name:</label>
-              <input
-                id="projectName"
-                type="text"
-                value={newProjectName}
-                onChange={(e) => setNewProjectName(e.target.value)}
-                required
-              />
-            </div>
-            <div>
-              <label htmlFor="projectPrefix">Project Prefix (e.g., PROJ):</label>
-              <input
-                id="projectPrefix"
-                type="text"
-                value={newProjectPrefix}
-                onChange={(e) => setNewProjectPrefix(e.target.value)}
-                maxLength={10}
-                required
-              />
-            </div>
-            <button type="submit" disabled={isCreating}>
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Create New Project"
+      >
+        <form onSubmit={handleCreateProject}>
+          {/* Remove the h2 title from here as it's now a prop of Modal */}
+          <div>
+            <label htmlFor="projectName">Project Name:</label>
+            <input
+              id="projectName"
+              type="text"
+              value={newProjectName}
+              onChange={(e) => setNewProjectName(e.target.value)}
+              required
+              style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+            />
+          </div>
+          <div>
+            <label htmlFor="projectPrefix">Project Prefix (e.g., PROJ):</label>
+            <input
+              id="projectPrefix"
+              type="text"
+              value={newProjectPrefix}
+              onChange={(e) => setNewProjectPrefix(e.target.value)}
+              maxLength={10}
+              required
+              style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+            />
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
+            <button type="button" onClick={() => setIsModalOpen(false)} style={{ padding: '8px 15px' }}>
+              Cancel
+            </button>
+            <button type="submit" disabled={isCreating} style={{ padding: '8px 15px' }}>
               {isCreating ? 'Creating...' : 'Create Project'}
             </button>
-            <button type="button" onClick={() => setIsModalOpen(false)}>Cancel</button>
-          </form>
-        </div>
-      )}
+          </div>
+        </form>
+      </Modal>
 
       {projects.length === 0 ? (
         <p>No projects yet. Create one to get started!</p>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -80,7 +80,7 @@ const DashboardPage: React.FC = () => {
               value={newProjectName}
               onChange={(e) => setNewProjectName(e.target.value)}
               required
-              style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+              className={styles.formInput}
             />
           </div>
           <div>
@@ -92,14 +92,22 @@ const DashboardPage: React.FC = () => {
               onChange={(e) => setNewProjectPrefix(e.target.value)}
               maxLength={10}
               required
-              style={{ width: '100%', padding: '8px', boxSizing: 'border-box', marginBottom: '10px' }}
+              className={styles.formInput}
             />
           </div>
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
-            <button type="button" onClick={() => setIsModalOpen(false)} style={{ padding: '8px 15px' }}>
+          <div className={styles.formActions}>
+            <button
+              type="button"
+              onClick={() => setIsModalOpen(false)}
+              className={`${styles.button} ${styles.buttonSecondary}`}
+            >
               Cancel
             </button>
-            <button type="submit" disabled={isCreating} style={{ padding: '8px 15px' }}>
+            <button
+              type="submit"
+              disabled={isCreating}
+              className={`${styles.button} ${styles.buttonPrimary}`}
+            >
               {isCreating ? 'Creating...' : 'Create Project'}
             </button>
           </div>

--- a/client/src/shared/ui/Modal/Modal.module.css
+++ b/client/src/shared/ui/Modal/Modal.module.css
@@ -1,0 +1,51 @@
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensure it's above other content */
+}
+
+.modalContent {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  min-width: 300px;
+  max-width: 90%;
+  max-height: 90vh; /* Max height */
+  overflow-y: auto; /* Allow scrolling for content that exceeds max height */
+  position: relative; /* For positioning the close button */
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1; /* Ensure the '×' is aligned well */
+}
+
+.modalBody {
+  /* Styles for the modal body if needed */
+}

--- a/client/src/shared/ui/Modal/Modal.spec.tsx
+++ b/client/src/shared/ui/Modal/Modal.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import Modal from './Modal';
+
+describe('Modal Component', () => {
+  const mockOnClose = vi.fn();
+  const modalTitle = 'Test Modal Title';
+  const modalChildText = 'This is the modal content.';
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup(); // Clean up DOM after each test
+  });
+
+  test('renders null when isOpen is false', () => {
+    const { container } = render(
+      <Modal isOpen={false} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText(modalTitle)).not.toBeInTheDocument();
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders correctly with title and children when isOpen is true', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    expect(screen.getByRole('dialog', { name: modalTitle })).toBeVisible();
+    expect(screen.getByText(modalChildText)).toBeVisible();
+    expect(screen.getByRole('button', { name: /close modal/i })).toBeVisible();
+  });
+
+  test('renders correctly without title when isOpen is true', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(screen.queryByText(modalTitle)).not.toBeInTheDocument();
+    expect(screen.getByText(modalChildText)).toBeVisible();
+  });
+
+
+  test('calls onClose when the close button is clicked', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close modal/i }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose when the backdrop is clicked', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    const dialogElement = screen.getByRole('dialog', { name: modalTitle });
+    if (dialogElement.parentElement) {
+      fireEvent.click(dialogElement.parentElement);
+    } else {
+      throw new Error("Dialog parent element (backdrop) not found");
+    }
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onClose when the modal content (dialog itself) is clicked', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    fireEvent.click(screen.getByRole('dialog', { name: modalTitle }));
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  test('does not call onClose when a child element within modal content is clicked', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    fireEvent.click(screen.getByText(modalChildText));
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  test('calls onClose when the Escape key is pressed', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <p>{modalChildText}</p>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders children correctly', () => {
+    render(
+      <Modal isOpen={true} onClose={mockOnClose} title={modalTitle}>
+        <div>
+          <span>{modalChildText}</span>
+          <button>Another Action</button>
+        </div>
+      </Modal>
+    );
+    expect(screen.getByText(modalChildText)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Another Action' })).toBeInTheDocument();
+  });
+
+  test('manages document event listener for Escape key correctly', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+    const { rerender, unmount } = render( // Use unmount from render
+      <Modal isOpen={true} onClose={mockOnClose} title="Esc Test">
+        Content
+      </Modal>
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    const escapeKeyHandler = addEventListenerSpy.mock.calls.find(call => call[0] === 'keydown')[1];
+
+    rerender(
+      <Modal isOpen={false} onClose={mockOnClose} title="Esc Test">
+        Content
+      </Modal>
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', escapeKeyHandler);
+
+    rerender(
+      <Modal isOpen={true} onClose={mockOnClose} title="Esc Test">
+        Content
+      </Modal>
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    const newEscapeKeyHandler = addEventListenerSpy.mock.calls.reverse().find(call => call[0] === 'keydown')[1];
+
+    unmount(); // Call unmount
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', newEscapeKeyHandler);
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/client/src/shared/ui/Modal/Modal.tsx
+++ b/client/src/shared/ui/Modal/Modal.tsx
@@ -31,9 +31,9 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
 
   return (
     <div className={styles.backdrop} onClick={onClose}>
-      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby={title ? "modal-title-id" : undefined}>
         <header className={styles.modalHeader}>
-          {title && <h2 className={styles.modalTitle}>{title}</h2>}
+          {title && <h2 className={styles.modalTitle} id="modal-title-id">{title}</h2>}
           <button onClick={onClose} className={styles.closeButton} aria-label="Close modal">
             &times;
           </button>

--- a/client/src/shared/ui/Modal/Modal.tsx
+++ b/client/src/shared/ui/Modal/Modal.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscKey);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <header className={styles.modalHeader}>
+          {title && <h2 className={styles.modalTitle}>{title}</h2>}
+          <button onClick={onClose} className={styles.closeButton} aria-label="Close modal">
+            &times;
+          </button>
+        </header>
+        <div className={styles.modalBody}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/client/src/shared/ui/Modal/index.ts
+++ b/client/src/shared/ui/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from './Modal';

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './Modal';


### PR DESCRIPTION
I replaced inline modal implementations in DashboardPage and BoardPage with a new reusable Modal component.

Key changes:
- I created a new `Modal` component (`client/src/shared/ui/Modal/Modal.tsx`) with consistent styling and behavior (overlay, backdrop click to close, Escape key to close, close button).
- I integrated this `Modal` component into `DashboardPage.tsx` for the "Create New Project" flow.
- I integrated this `Modal` component into `BoardPage.tsx` for the "Add New Task" flow.

This change ensures a consistent user experience for modal dialogs and improves code reusability. The core functionality of creating projects and tasks remains unchanged.