### PR TITLE
feat: Implement new task fields and relocate add task button

### DIFF
--- a/api/db/changelog/db.changelog-0.2.xml
+++ b/api/db/changelog/db.changelog-0.2.xml
@@ -13,7 +13,7 @@
             <column name="priority" type="VARCHAR(255)"/>
         </addColumn>
         <addColumn tableName="tasks">
-            <column name="tags" type="TEXT[]"/> <!-- Assuming PostgreSQL for TEXT[] -->
+            <column name="tags" type="VARCHAR(255)[]"/> <!-- Changed from TEXT[] -->
         </addColumn>
         <!-- due_date is already expected to be in the table, if not, it should have been in an earlier migration.
              If it needs to be added now, uncomment and adjust:

--- a/api/db/changelog/db.changelog-0.2.xml
+++ b/api/db/changelog/db.changelog-0.2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="20240315-add-task-fields" author="jules">
+        <addColumn tableName="tasks">
+            <column name="type" type="VARCHAR(255)"/>
+        </addColumn>
+        <addColumn tableName="tasks">
+            <column name="priority" type="VARCHAR(255)"/>
+        </addColumn>
+        <addColumn tableName="tasks">
+            <column name="tags" type="TEXT[]"/> <!-- Assuming PostgreSQL for TEXT[] -->
+        </addColumn>
+        <!-- due_date is already expected to be in the table, if not, it should have been in an earlier migration.
+             If it needs to be added now, uncomment and adjust:
+        <addColumn tableName="tasks">
+            <column name="due_date" type="TIMESTAMPTZ"/>
+        </addColumn>
+        -->
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -7,5 +7,6 @@
 
     <!-- Include other changelog files here -->
     <include file="db/changelog/db.changelog-0.1.xml"/>
+    <include file="db/changelog/db.changelog-0.2.xml"/>
 
 </databaseChangeLog>

--- a/api/src/tasks/dto/create-task.dto.ts
+++ b/api/src/tasks/dto/create-task.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength, IsInt, IsArray } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength, IsInt, IsArray, IsDateString } from 'class-validator';
 
 export class CreateTaskDto {
   @IsString()
@@ -26,7 +26,7 @@ export class CreateTaskDto {
   // position will be handled by the service, typically added at the end of the column
 
   @IsOptional()
-  @IsString()
+  @IsDateString() // Changed from IsString
   dueDate?: string; // ISO date string
 
   @IsOptional()

--- a/api/src/tasks/dto/create-task.dto.ts
+++ b/api/src/tasks/dto/create-task.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength, IsInt } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength, IsInt, IsArray } from 'class-validator';
 
 export class CreateTaskDto {
   @IsString()
@@ -24,4 +24,23 @@ export class CreateTaskDto {
   assigneeId?: string;
 
   // position will be handled by the service, typically added at the end of the column
+
+  @IsOptional()
+  @IsString()
+  dueDate?: string; // ISO date string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  priority?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
 }

--- a/api/src/tasks/dto/update-task.dto.ts
+++ b/api/src/tasks/dto/update-task.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsUUID, MaxLength, IsInt, IsArray } from 'class-validator';
+import { IsString, IsOptional, IsUUID, MaxLength, IsInt, IsArray, IsDateString } from 'class-validator';
 
 export class UpdateTaskDto {
   @IsString()
@@ -24,7 +24,7 @@ export class UpdateTaskDto {
   position?: number;
 
   @IsOptional()
-  @IsString()
+  @IsDateString() // Changed from IsString
   dueDate?: string;
 
   @IsOptional()

--- a/api/src/tasks/dto/update-task.dto.ts
+++ b/api/src/tasks/dto/update-task.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsUUID, MaxLength, IsInt } from 'class-validator';
+import { IsString, IsOptional, IsUUID, MaxLength, IsInt, IsArray } from 'class-validator';
 
 export class UpdateTaskDto {
   @IsString()
@@ -22,4 +22,23 @@ export class UpdateTaskDto {
   @IsInt()
   @IsOptional()
   position?: number;
+
+  @IsOptional()
+  @IsString()
+  dueDate?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  priority?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
 }

--- a/api/src/types/db-records.d.ts
+++ b/api/src/types/db-records.d.ts
@@ -41,6 +41,9 @@ export interface TaskRecord {
   assignee_id: string | null; // Foreign key to UserRecord.id
   creator_id: string; // Foreign key to UserRecord.id
   due_date: Date | null;
+  type: string | null;
+  priority: string | null;
+  tags: string[] | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -10,9 +10,21 @@ import LandingPage from '../pages/LandingPage'; // Import LandingPage
 import NotFoundPage from '../pages/NotFoundPage'; // Import NotFoundPage
 import { useAuth } from './auth/AuthContext'; // Import the real useAuth
 import Header from '../widgets/Header/Header';
+import { AddTaskModalContext } from '../shared/contexts/AddTaskModalContext'; // Import the context
+import { useState } from 'react'; // Import useState
 
 const App: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth(); // Use real useAuth, include isLoading
+  const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
+
+  const openAddTaskModal = () => setIsAddTaskModalOpen(true);
+  const closeAddTaskModal = () => setIsAddTaskModalOpen(false);
+
+  const addTaskModalContextValue = {
+    isModalOpen: isAddTaskModalOpen,
+    openModal: openAddTaskModal,
+    closeModal: closeAddTaskModal,
+  };
 
   // Optional: Show a global loading spinner while AuthContext is initializing
   if (isLoading) {
@@ -20,11 +32,12 @@ const App: React.FC = () => {
   }
 
   return (
-    <Router>
-      <Header />
-      <Routes>
-        {/* Root route: Landing page for unauthenticated, redirect to dashboard for authenticated */}
-        <Route path="/" element={isAuthenticated ? <Navigate to="/dashboard" /> : <LandingPage />} />
+    <AddTaskModalContext.Provider value={addTaskModalContextValue}>
+      <Router>
+        <Header />
+        <Routes>
+          {/* Root route: Landing page for unauthenticated, redirect to dashboard for authenticated */}
+          <Route path="/" element={isAuthenticated ? <Navigate to="/dashboard" /> : <LandingPage />} />
 
         {/* Auth routes: Redirect to dashboard if authenticated, otherwise show login/register */}
         <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" /> : <LoginPage />} />
@@ -44,8 +57,9 @@ const App: React.FC = () => {
         <Route path="/404" element={<NotFoundPage />} />
         <Route path="*" element={<Navigate to="/404" replace />} /> {/* Catch-all route */}
 
-      </Routes>
-    </Router>
+        </Routes>
+      </Router>
+    </AddTaskModalContext.Provider>
   );
 };
 

--- a/client/src/features/ColumnLane/ColumnLane.tsx
+++ b/client/src/features/ColumnLane/ColumnLane.tsx
@@ -11,11 +11,11 @@ interface Column extends ProjectColumnDto {
 
 interface ColumnLaneProps {
   column: Column;
-  onAddTask: (columnId: string) => void; // Function to open add task modal
+  // onAddTask: (columnId: string) => void; // Function to open add task modal - REMOVED
   onTaskClick: (task: TaskDto) => void; // New prop for task click
 }
 
-const ColumnLane: React.FC<ColumnLaneProps> = ({ column, onAddTask, onTaskClick }) => {
+const ColumnLane: React.FC<ColumnLaneProps> = ({ column, onTaskClick }) => {
   const { setNodeRef, isOver } = useDroppable({ id: column.id });
 
   const style = {
@@ -47,11 +47,7 @@ const ColumnLane: React.FC<ColumnLaneProps> = ({ column, onAddTask, onTaskClick 
           )}
         </SortableContext>
       </div>
-      <button
-        className={`${styles.addTaskButton} secondary`}
-        onClick={() => onAddTask(column.id)}>
-        + Add Task
-      </button>
+      {/* Removed Add Task Button from here */}
     </div>
   );
 };

--- a/client/src/features/TaskCard/TaskCard.tsx
+++ b/client/src/features/TaskCard/TaskCard.tsx
@@ -44,10 +44,28 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onTaskClick }) => {
           {task.description}
         </div>
       )}
-      {/* Example for task meta, if you add it later */}
-      {/* <div className={styles.taskMeta}>
-        <span>ID: {task.humanReadableId}</span>
-      </div> */}
+      <div className={styles.taskMeta}>
+        {task.priority && (
+          <span className={`${styles.metaItem} ${styles.priority} ${styles['priority' + task.priority.charAt(0).toUpperCase() + task.priority.slice(1)]}`}>
+            Priority: {task.priority}
+          </span>
+        )}
+        {task.dueDate && (
+          <span className={styles.metaItem}>
+            Due: {new Date(task.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}
+          </span>
+        )}
+      </div>
+      {task.tags && task.tags.length > 0 && (
+        <div className={styles.tagsContainer}>
+          {task.tags.slice(0, 3).map(tag => ( // Show up to 3 tags
+            <span key={tag} className={styles.tag}>{tag}</span>
+          ))}
+          {task.tags.length > 3 && (
+            <span className={styles.tagMore}>+{task.tags.length - 3} more</span>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
@@ -119,16 +119,21 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
     setIsUpdatingTask(true);
     setUpdateError(null);
 
-    const tagsArray = editableTags.split(',').map(tag => tag.trim()).filter(tag => tag);
+    const tagsArray = editableTags.trim() ? editableTags.split(',').map(tag => tag.trim()).filter(tag => tag) : [];
 
     const updateData: UpdateTaskDto = {
-      title: editableTitle,
-      description: editableDescription || undefined, // Send undefined if empty
-      dueDate: editableDueDate || undefined,
-      type: editableType || undefined,
-      priority: editablePriority || undefined,
-      tags: tagsArray.length > 0 ? tagsArray : undefined,
+      title: editableTitle, // Assuming title cannot be cleared to empty, or if so, '' is acceptable
+      description: editableDescription, // Send '' if cleared, backend DTO allows string | null
+      dueDate: editableDueDate ? editableDueDate : null, // Send null if date input is cleared (empty string)
+      type: editableType, // Send '' if cleared
+      priority: editablePriority, // Send '' if cleared
+      tags: tagsArray, // Send [] if cleared
     };
+
+    // Note: The backend UpdateTaskDto allows null for these fields.
+    // If an empty string ('') should explicitly be stored as null by the backend,
+    // the backend service (tasks.service.ts updateTask method) would need to handle that conversion.
+    // For now, the client sends '' for cleared text fields, null for cleared date, and [] for cleared tags.
 
     try {
       await taskService.updateTask(task.id, updateData);

--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
@@ -2,8 +2,10 @@
 import React, { useEffect, useState, useCallback } from 'react';
 // Use CommentDto from taskService, TaskDto from projectService
 import type { TaskDto } from '../../../shared/api/projectService';
-import type { CommentDto, ApiCommentDto } from '../../../shared/api/taskService';
+import { taskService } from '../../../shared/api/taskService'; // Import taskService
+import type { UpdateTaskDto, CommentDto, ApiCommentDto } from '../../../shared/api/taskService'; // Import UpdateTaskDto
 import { transformCommentDto } from '../../../shared/api/taskService';
+
 import { getTaskComments } from '../../Comments/api';
 import { CommentList, AddCommentForm } from '../../Comments';
 import { socket } from '../../../shared/lib/socket';
@@ -20,6 +22,30 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
   const [comments, setComments] = useState<CommentDto[]>([]);
   const [isLoadingComments, setIsLoadingComments] = useState(false);
   const [errorComments, setErrorComments] = useState<string | null>(null);
+
+  // Editing state
+  const [isEditing, setIsEditing] = useState(false);
+  const [editableTitle, setEditableTitle] = useState('');
+  const [editableDescription, setEditableDescription] = useState('');
+  const [editableDueDate, setEditableDueDate] = useState('');
+  const [editableType, setEditableType] = useState('');
+  const [editablePriority, setEditablePriority] = useState('');
+  const [editableTags, setEditableTags] = useState(''); // Comma-separated string for input
+  const [isUpdatingTask, setIsUpdatingTask] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+
+  // Initialize editable fields when task changes or modal opens
+  useEffect(() => {
+    if (task) {
+      setEditableTitle(task.title);
+      setEditableDescription(task.description || '');
+      setEditableDueDate(task.dueDate ? new Date(task.dueDate).toISOString().split('T')[0] : '');
+      setEditableType(task.type || '');
+      setEditablePriority(task.priority || '');
+      setEditableTags(task.tags ? task.tags.join(', ') : '');
+    }
+  }, [task, isOpen]); // Re-run if isOpen changes to ensure reset if modal is reopened with same task
 
   const fetchComments = useCallback(async () => {
     if (!task) return;
@@ -72,22 +98,126 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
 
   if (!isOpen || !task) return null;
 
+  const handleEditToggle = () => {
+    if (isEditing) {
+      // Reset fields if canceling edit
+      if (task) {
+        setEditableTitle(task.title);
+        setEditableDescription(task.description || '');
+        setEditableDueDate(task.dueDate ? new Date(task.dueDate).toISOString().split('T')[0] : '');
+        setEditableType(task.type || '');
+        setEditablePriority(task.priority || '');
+        setEditableTags(task.tags ? task.tags.join(', ') : '');
+      }
+    }
+    setIsEditing(!isEditing);
+    setUpdateError(null); // Clear any previous update errors
+  };
+
+  const handleSaveChanges = async () => {
+    if (!task) return;
+    setIsUpdatingTask(true);
+    setUpdateError(null);
+
+    const tagsArray = editableTags.split(',').map(tag => tag.trim()).filter(tag => tag);
+
+    const updateData: UpdateTaskDto = {
+      title: editableTitle,
+      description: editableDescription || undefined, // Send undefined if empty
+      dueDate: editableDueDate || undefined,
+      type: editableType || undefined,
+      priority: editablePriority || undefined,
+      tags: tagsArray.length > 0 ? tagsArray : undefined,
+    };
+
+    try {
+      await taskService.updateTask(task.id, updateData);
+      setIsEditing(false);
+      // Relies on WebSocket event (task:updated) to update BoardPage and thus this modal's task prop
+    } catch (error: any) {
+      console.error('Failed to update task:', error);
+      setUpdateError(error.message || 'Failed to update task. Please try again.');
+    } finally {
+      setIsUpdatingTask(false);
+    }
+  };
+
+  // Basic date formatter for display
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return 'Not set';
+    return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+  };
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
       <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.taskDetails}>
-          <h2>{task.humanReadableId}: {task.title}</h2>
-          <p>{task.description || 'No description.'}</p>
-          {/* Add more task details here: Assignee, Due Date, etc. */}
-        </div>
-        <div className={styles.commentsSection}>
-          <h3>Comments</h3>
-          {isLoadingComments && <p>Loading comments...</p>}
-          {errorComments && <p style={{color: 'red'}}>{errorComments}</p>}
-          {!isLoadingComments && <CommentList comments={comments} />}
-          <AddCommentForm taskId={task.id} onCommentAdded={handleCommentAdded} />
-        </div>
-        <button onClick={onClose} className={styles.closeButton}>Close</button>
+        {isEditing ? (
+          // EDIT MODE
+          <div className={styles.taskEditForm}>
+            <h3>Edit Task</h3>
+            <div>
+              <label htmlFor="editTaskTitle">Title:</label>
+              <input id="editTaskTitle" type="text" value={editableTitle} onChange={e => setEditableTitle(e.target.value)} className={styles.formInputFull} />
+            </div>
+            <div>
+              <label htmlFor="editTaskDesc">Description:</label>
+              <textarea id="editTaskDesc" value={editableDescription} onChange={e => setEditableDescription(e.target.value)} className={styles.formTextareaFull} />
+            </div>
+            <div>
+              <label htmlFor="editTaskDueDate">Due Date:</label>
+              <input id="editTaskDueDate" type="date" value={editableDueDate} onChange={e => setEditableDueDate(e.target.value)} className={styles.formInput} />
+            </div>
+            <div>
+              <label htmlFor="editTaskType">Type:</label>
+              <input id="editTaskType" type="text" value={editableType} onChange={e => setEditableType(e.target.value)} className={styles.formInput} placeholder="e.g., Bug, Feature"/>
+            </div>
+            <div>
+              <label htmlFor="editTaskPriority">Priority:</label>
+              <input id="editTaskPriority" type="text" value={editablePriority} onChange={e => setEditablePriority(e.target.value)} className={styles.formInput} placeholder="e.g., High, Medium, Low"/>
+            </div>
+            <div>
+              <label htmlFor="editTaskTags">Tags (comma-separated):</label>
+              <input id="editTaskTags" type="text" value={editableTags} onChange={e => setEditableTags(e.target.value)} className={styles.formInputFull} placeholder="e.g., UI, Backend"/>
+            </div>
+            {updateError && <p className={styles.errorText}>{updateError}</p>}
+            <div className={styles.editActions}>
+              <button onClick={handleEditToggle} disabled={isUpdatingTask} className={`${styles.button} ${styles.buttonSecondary}`}>Cancel</button>
+              <button onClick={handleSaveChanges} disabled={isUpdatingTask} className={`${styles.button} ${styles.buttonPrimary}`}>
+                {isUpdatingTask ? 'Saving...' : 'Save Changes'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          // VIEW MODE
+          <>
+            <div className={styles.taskDetails}>
+              <div className={styles.taskHeader}>
+                <h2>{task.humanReadableId}: {task.title}</h2>
+                <button onClick={handleEditToggle} className={`${styles.button} ${styles.buttonLink}`}>Edit</button>
+              </div>
+              <p className={styles.description}>{task.description || 'No description.'}</p>
+              <div className={styles.metaGrid}>
+                <div><strong>Due Date:</strong> {formatDate(task.dueDate)}</div>
+                <div><strong>Type:</strong> {task.type || 'Not set'}</div>
+                <div><strong>Priority:</strong> {task.priority || 'Not set'}</div>
+              </div>
+              {task.tags && task.tags.length > 0 && (
+                <div className={styles.tagsDisplay}>
+                  <strong>Tags:</strong>
+                  {task.tags.map(tag => <span key={tag} className={styles.tagItem}>{tag}</span>)}
+                </div>
+              )}
+            </div>
+            <div className={styles.commentsSection}>
+              <h3>Comments</h3>
+              {isLoadingComments && <p>Loading comments...</p>}
+              {errorComments && <p style={{color: 'red'}}>{errorComments}</p>}
+              {!isLoadingComments && <CommentList comments={comments} />}
+              <AddCommentForm taskId={task.id} onCommentAdded={handleCommentAdded} />
+            </div>
+          </>
+        )}
+        <button onClick={onClose} className={styles.closeButtonModal}>Close</button>
       </div>
     </div>
   );

--- a/client/src/pages/BoardPage.tsx
+++ b/client/src/pages/BoardPage.tsx
@@ -24,6 +24,7 @@ import styles from './BoardPage.module.css'; // Import css modules
 import ColumnLane from '../features/ColumnLane/ColumnLane'; // Import ColumnLane
 import { ManageProjectMembersModal } from '../features/ProjectMembers'; // Import ManageProjectMembersModal
 import { TaskDetailModal } from '../features/TaskDetailModal'; // Import TaskDetailModal
+import { AddTaskModalContext } from '../shared/contexts/AddTaskModalContext'; // Import the context
 
 // interfaces Column, BoardData as before
 interface Column extends ProjectColumnDto {
@@ -50,6 +51,10 @@ const BoardPage: React.FC = () => {
   const [selectedColumnId, setSelectedColumnId] = useState<string | null>(null);
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [newTaskDescription, setNewTaskDescription] = useState('');
+  const [newTaskDueDate, setNewTaskDueDate] = useState('');
+  const [newTaskType, setNewTaskType] = useState('');
+  const [newTaskPriority, setNewTaskPriority] = useState('');
+  const [newTaskTags, setNewTaskTags] = useState(''); // Comma-separated string
   const [isCreatingTask, setIsCreatingTask] = useState(false);
 
 
@@ -185,20 +190,55 @@ const BoardPage: React.FC = () => {
     }
   }, [projectId, fetchBoardData, numericProjectId]);
 
-  const openAddTaskModal = (columnId: string) => {
-    setSelectedColumnId(columnId);
+  const openAddTaskModal = () => {
+    // Initialize selectedColumnId to the first column if available, or null
+    if (boardData && boardData.columns.length > 0) {
+      setSelectedColumnId(boardData.columns[0].id);
+    } else {
+      setSelectedColumnId(null); // Or handle case where no columns exist yet
+    }
     setIsAddTaskModalOpen(true);
   };
+
+  const resetAddTaskForm = () => {
+    setNewTaskTitle('');
+    setNewTaskDescription('');
+    setNewTaskDueDate('');
+    setNewTaskType('');
+    setNewTaskPriority('');
+    setNewTaskTags('');
+    // setSelectedColumnId(null); // Keep selectedColumnId as is, or reset based on UX preference
+    setIsAddTaskModalOpen(false);
+  };
+
   const handleCreateTask = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newTaskTitle.trim() || !selectedColumnId || numericProjectId === null) return;
+    if (!newTaskTitle.trim() || !selectedColumnId || numericProjectId === null) {
+      alert('Please ensure Title and Column are filled.'); // Basic validation
+      return;
+    }
     setIsCreatingTask(true);
     try {
-      const taskData: CreateTaskDto = { title: newTaskTitle, description: newTaskDescription, columnId: selectedColumnId, projectId: numericProjectId };
+      const tagsArray = newTaskTags.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0);
+      const taskData: CreateTaskDto = {
+        title: newTaskTitle,
+        description: newTaskDescription,
+        columnId: selectedColumnId,
+        projectId: numericProjectId,
+        dueDate: newTaskDueDate || undefined, // Send undefined if empty, so backend can ignore or use null
+        type: newTaskType || undefined,
+        priority: newTaskPriority || undefined,
+        tags: tagsArray.length > 0 ? tagsArray : undefined,
+      };
       await taskService.createTask(taskData);
-      setNewTaskTitle(''); setNewTaskDescription(''); setIsAddTaskModalOpen(false); setSelectedColumnId(null);
-    } catch (err) { console.error('Failed to create task:', err); alert('Failed to create task.');
-    } finally { setIsCreatingTask(false); }
+      resetAddTaskForm();
+      // No need to set selectedColumnId to null here if we want it to persist for the next task
+    } catch (err) {
+      console.error('Failed to create task:', err);
+      alert('Failed to create task.');
+    } finally {
+      setIsCreatingTask(false);
+    }
   };
 
   const handleTaskClick = (task: TaskDto) => { // Handler for task click
@@ -345,8 +385,15 @@ const BoardPage: React.FC = () => {
   if (error) return <p style={{ color: 'red' }}>{error}</p>;
   if (!boardData) return <p>No board data found or project ID is invalid.</p>;
 
+  const modalContextValue = {
+    isModalOpen: isAddTaskModalOpen,
+    openModal: openAddTaskModal, // This already handles setting state and pre-selecting column
+    closeModal: resetAddTaskForm, // This already handles closing modal and resetting form
+  };
+
   return (
-    <> {/* Using React Fragment to wrap DndContext and Modal */}
+    <AddTaskModalContext.Provider value={modalContextValue}>
+      {/* Using React Fragment to wrap DndContext and Modal */}
       <DndContext
         sensors={sensors}
         collisionDetection={closestCorners}
@@ -367,19 +414,12 @@ const BoardPage: React.FC = () => {
           {selectedColumnId && ( // Keep selectedColumnId check if it ensures boardData.columns.find is safe
             <Modal
               isOpen={isAddTaskModalOpen}
-              onClose={() => {
-                setIsAddTaskModalOpen(false);
-                // Optionally reset form fields here if not done elsewhere
-                // setNewTaskTitle('');
-                // setNewTaskDescription('');
-                // setSelectedColumnId(null); // This might be needed if modal can open before selectedColumnId is ready
-              }}
-              title={`Add New Task to ${boardData?.columns.find(c => c.id === selectedColumnId)?.name || 'Column'}`}
+              onClose={resetAddTaskForm} // Use the reset function on close
+              title="Add New Task" // Generic title
             >
-              <form onSubmit={handleCreateTask}>
-                {/* The h2 title is removed as it's now a prop of Modal */}
+              <form onSubmit={handleCreateTask} className={styles.form}>
                 <div>
-                  <label htmlFor="taskTitle">Task Title:</label>
+                  <label htmlFor="taskTitle" className={styles.formLabel}>Task Title:</label>
                   <input
                     id="taskTitle"
                     type="text"
@@ -395,31 +435,90 @@ const BoardPage: React.FC = () => {
                     id="taskDescription"
                     value={newTaskDescription}
                     onChange={(e) => setNewTaskDescription(e.target.value)}
-              className={styles.formTextarea}
+                    className={styles.formTextarea}
                   />
                 </div>
-          <div className={styles.formActions}>
+                <div>
+                  <label htmlFor="columnSelect" className={styles.formLabel}>Status/Column:</label>
+                  <select
+                    id="columnSelect"
+                    value={selectedColumnId || ''}
+                    onChange={(e) => setSelectedColumnId(e.target.value)}
+                    required
+                    className={styles.formSelect}
+                  >
+                    <option value="" disabled>Select a column</option>
+                    {boardData?.columns.map(column => (
+                      <option key={column.id} value={column.id}>{column.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="taskDueDate" className={styles.formLabel}>Deadline:</label>
+                  <input
+                    id="taskDueDate"
+                    type="date"
+                    value={newTaskDueDate}
+                    onChange={(e) => setNewTaskDueDate(e.target.value)}
+                    className={styles.formInput}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="taskType" className={styles.formLabel}>Type:</label>
+                  <input
+                    id="taskType"
+                    type="text"
+                    value={newTaskType}
+                    onChange={(e) => setNewTaskType(e.target.value)}
+                    className={styles.formInput}
+                    placeholder="e.g., Bug, Feature, Chore"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="taskPriority" className={styles.formLabel}>Priority:</label>
+                  <input
+                    id="taskPriority"
+                    type="text"
+                    value={newTaskPriority}
+                    onChange={(e) => setNewTaskPriority(e.target.value)}
+                    className={styles.formInput}
+                    placeholder="e.g., High, Medium, Low"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="taskTags" className={styles.formLabel}>Tags (comma-separated):</label>
+                  <input
+                    id="taskTags"
+                    type="text"
+                    value={newTaskTags}
+                    onChange={(e) => setNewTaskTags(e.target.value)}
+                    className={styles.formInput}
+                    placeholder="e.g., UI, Backend, Urgent"
+                  />
+                </div>
+                <div className={styles.formActions}>
                   <button
                     type="button"
-                    onClick={() => setIsAddTaskModalOpen(false)}
-              className={`${styles.button} ${styles.buttonSecondary}`}
+                    onClick={resetAddTaskForm} // Use reset function
+                    className={`${styles.button} ${styles.buttonSecondary}`}
                   >
                     Cancel
                   </button>
-            <button
-              type="submit"
-              disabled={isCreatingTask}
-              className={`${styles.button} ${styles.buttonPrimary}`}
-            >
+                  <button
+                    type="submit"
+                    disabled={isCreatingTask || !selectedColumnId} // Also disable if no column selected
+                    className={`${styles.button} ${styles.buttonPrimary}`}
+                  >
                     {isCreatingTask ? 'Creating...' : 'Create Task'}
                   </button>
                 </div>
               </form>
             </Modal>
           )}
+          {/* Removed global Add New Task button from here */}
           <div style={{ display: 'flex', gap: '16px', overflowX: 'auto', padding: '10px', minHeight: 'calc(100vh - 100px)' }}>
             {boardData.columns.map((column) => (
-              <ColumnLane key={column.id} column={column} onAddTask={openAddTaskModal} onTaskClick={handleTaskClick} />
+              <ColumnLane key={column.id} column={column} onTaskClick={handleTaskClick} />
           ))}
         </div>
       </div>
@@ -440,7 +539,7 @@ const BoardPage: React.FC = () => {
       />
     )}
     <DragOverlay>{activeDragId ? <div style={{ border: '1px solid gray', padding: '10px', backgroundColor: 'lightyellow' }}>Dragging: {activeDragId}</div> : null}</DragOverlay>
-    </>
+    </AddTaskModalContext.Provider>
   );
 };
 export default BoardPage;

--- a/client/src/shared/api/projectService.ts
+++ b/client/src/shared/api/projectService.ts
@@ -25,7 +25,10 @@ export interface TaskDto {
   columnId: string;
   assigneeId?: string;
   creatorId: string;
-  dueDate?: Date;
+  dueDate?: string; // Kept as string, client can parse if needed
+  type?: string;
+  priority?: string;
+  tags?: string[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/client/src/shared/api/taskService.ts
+++ b/client/src/shared/api/taskService.ts
@@ -7,6 +7,24 @@ export interface CreateTaskDto {
   columnId: string;
   projectId: number; // Ensure this is passed from BoardPage
   assigneeId?: string;
+  // Fields from previous CreateTaskDto in backend, to be aligned with TaskRecord
+  dueDate?: string;
+  type?: string;
+  priority?: string;
+  tags?: string[];
+}
+
+// For updating tasks, all fields are optional
+export interface UpdateTaskDto {
+  title?: string;
+  description?: string;
+  columnId?: string; // Usually handled by move, but can be here for general updates
+  assigneeId?: string | null; // Allow setting to null
+  dueDate?: string | null; // Allow setting to null
+  type?: string | null; // Allow setting to null
+  priority?: string | null; // Allow setting to null
+  tags?: string[] | null; // Allow setting to null
+  position?: number; // If position is also updatable directly
 }
 
 export interface MoveTaskDto {
@@ -38,7 +56,11 @@ export const taskService = {
     const response = await apiClient.patch<TaskDto>(`/tasks/${taskId}/move`, data);
     return response.data;
   },
-  // Add other task-related API calls here if needed (e.g., updateTask, getTaskById)
+
+  updateTask: async (taskId: string, data: UpdateTaskDto): Promise<TaskDto> => {
+    const response = await apiClient.patch<TaskDto>(`/tasks/${taskId}`, data);
+    return response.data;
+  },
 
   getTaskComments: async (taskId: string): Promise<CommentDto[]> => {
     const response = await apiClient.get<ApiCommentDto[]>(`/tasks/${taskId}/comments`);

--- a/client/src/shared/contexts/AddTaskModalContext.tsx
+++ b/client/src/shared/contexts/AddTaskModalContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AddTaskModalContextType {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+const AddTaskModalContext = createContext<AddTaskModalContextType | undefined>(undefined);
+
+export const useAddTaskModal = () => {
+  const context = useContext(AddTaskModalContext);
+  if (!context) {
+    throw new Error('useAddTaskModal must be used within an AddTaskModalProvider');
+  }
+  return context;
+};
+
+// Note: The actual AddTaskModalProvider component will be implemented by integrating its logic
+// into BoardPage.tsx where the state and modal control functions (open/close) already exist.
+// This file primarily defines the context type and the consumer hook.
+// If a standalone Provider component was desired, it would look something like this:
+/*
+export const AddTaskModalProvider = ({ children }: { children: ReactNode }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // These would be generic open/close functions.
+  // The specific logic for what happens on open (like pre-selecting a column in BoardPage)
+  // would either need to be passed into this provider, or this provider would be
+  // more tightly coupled with BoardPage's specific needs if it were to manage that.
+  // For this exercise, BoardPage will provide these functions directly.
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  return (
+    <AddTaskModalContext.Provider value={{ isModalOpen, openModal, closeModal }}>
+      {children}
+    </AddTaskModalContext.Provider>
+  );
+};
+*/

--- a/client/src/widgets/Header/Header.tsx
+++ b/client/src/widgets/Header/Header.tsx
@@ -12,16 +12,10 @@ import { useAddTaskModal } from '../../shared/contexts/AddTaskModalContext'; // 
 
 const Header: React.FC = () => { // Remove props
   const { isAuthenticated, isLoading, user } = useAuth(); // Add user from useAuth
-  let openModalFromContext: (() => void) | null = null;
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { openModal } = useAddTaskModal(); // Get openModal from context
-    openModalFromContext = openModal;
-  } catch (error) {
-    // Context not available, means this Header instance is not rendered under a BoardPage
-    // or similar page that provides AddTaskModalContext. Button will not be shown.
-    // console.warn("AddTaskModalContext not found, 'Add Task' button will not be available in this Header instance.");
-  }
+  // Directly use the context. If the provider is missing, the useAddTaskModal hook will throw an error.
+  // This is generally desired in development to catch setup issues.
+  // App.tsx now guarantees the provider is present for Header.
+  const { openModal } = useAddTaskModal();
 
 
   return (
@@ -39,9 +33,9 @@ const Header: React.FC = () => { // Remove props
               <li>Loading...</li>
             ) : isAuthenticated && user ? ( // Check for user object as well
               <>
-                {openModalFromContext && ( // Conditionally render based on context availability
+                {openModal && ( // Conditionally render based on openModal from context
                   <li>
-                    <button onClick={openModalFromContext} className={styles.addTaskButtonHeader}>
+                    <button onClick={openModal} className={styles.addTaskButtonHeader}>
                       + Add Task
                     </button>
                   </li>

--- a/client/src/widgets/Header/Header.tsx
+++ b/client/src/widgets/Header/Header.tsx
@@ -3,9 +3,26 @@ import { useAuth } from '../../app/auth/AuthContext';
 import LogoutButton from '../../features/authByEmail/ui/LogoutButton';
 import { NotificationBell } from '../../features/Notifications'; // Import NotificationBell
 import styles from './Header.module.css';
+import { useAddTaskModal } from '../../shared/contexts/AddTaskModalContext'; // Import the hook
 
-const Header = () => {
+// No longer need HeaderProps for onOpenAddTaskModal
+// interface HeaderProps {
+//   onOpenAddTaskModal?: () => void;
+// }
+
+const Header: React.FC = () => { // Remove props
   const { isAuthenticated, isLoading, user } = useAuth(); // Add user from useAuth
+  let openModalFromContext: (() => void) | null = null;
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { openModal } = useAddTaskModal(); // Get openModal from context
+    openModalFromContext = openModal;
+  } catch (error) {
+    // Context not available, means this Header instance is not rendered under a BoardPage
+    // or similar page that provides AddTaskModalContext. Button will not be shown.
+    // console.warn("AddTaskModalContext not found, 'Add Task' button will not be available in this Header instance.");
+  }
+
 
   return (
     <header className={styles.header}>
@@ -22,6 +39,13 @@ const Header = () => {
               <li>Loading...</li>
             ) : isAuthenticated && user ? ( // Check for user object as well
               <>
+                {openModalFromContext && ( // Conditionally render based on context availability
+                  <li>
+                    <button onClick={openModalFromContext} className={styles.addTaskButtonHeader}>
+                      + Add Task
+                    </button>
+                  </li>
+                )}
                 <li className={styles.welcomeMessage}> {/* Optional: Add styling for welcome message */}
                   <span>Welcome, {user.name || user.email}</span>
                 </li>

--- a/client/src/widgets/Layout/MainLayout.tsx
+++ b/client/src/widgets/Layout/MainLayout.tsx
@@ -4,12 +4,13 @@ import styles from './MainLayout.module.css';
 
 interface MainLayoutProps {
   children: ReactNode;
+  // onOpenAddTaskModal?: () => void; // REMOVED - No longer needed
 }
 
-const MainLayout = ({ children }: MainLayoutProps) => {
+const MainLayout = ({ children }: MainLayoutProps) => { // Removed onOpenAddTaskModal from props
   return (
     <div className={styles.layoutContainer}>
-      <Header /> {/* Add Header component */}
+      <Header /> {/* REMOVED onOpenAddTaskModal prop */}
       <main className={styles.mainContent}>
         {children}
       </main>


### PR DESCRIPTION
This commit introduces several enhancements to task management:

New Task Fields:
- Added 'type', 'priority', 'tags', and 'dueDate' fields to tasks.
- Updated database schema (Liquibase migration) for the 'tasks' table.
- Modified backend DTOs (CreateTaskDto, UpdateTaskDto) and TaskService to support these new fields.
- Updated the shared TaskDto for client-side use.

UI Changes:
- Add Task Modal:
    - Form now includes inputs for deadline, type, priority, and tags.
    - Added a 'Status/Column' selector to choose the initial column for the new task.
- Relocated 'Add Task' Button:
    - Removed the button from individual Kanban columns.
    - Added a single 'Add Task' button to the main application header.
    - Implemented a React Context (AddTaskModalContext) for clean communication between the header button and the modal logic in BoardPage.
- Display and Edit New Fields:
    - Task cards now display priority, due date, and tags.
    - The Task Detail Modal now displays all new fields and allows them to be edited, saving changes via the TaskService.

Summary of steps taken:
- Part 1: Backend API Changes (All steps completed)
    - Updated Task entity and database schema.
    - Updated Task DTOs.
    - Updated Task Service.
    - Updated Shared Task DTO for client.
- Part 2: Frontend Client Changes (Steps 5-8 completed)
    - Updated client-side Task model.
    - Modified Add Task Modal and form.
    - Relocated 'Add Task' button (components modified, Context implemented for callback).
    - Implemented display and editing of new fields in TaskCard and TaskDetailModal.

I was planning to begin thorough testing of these features next.