### PR TITLE
Fix TypeScript errors in client build

### DIFF
--- a/client/src/features/ColumnLane/ColumnLane.tsx
+++ b/client/src/features/ColumnLane/ColumnLane.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './ColumnLane.module.css'; // Import the CSS module
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';
 import TaskCard from '../TaskCard/TaskCard'; // Adjust path

--- a/client/src/shared/contexts/AddTaskModalContext.tsx
+++ b/client/src/shared/contexts/AddTaskModalContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
 
 interface AddTaskModalContextType {
   isModalOpen: boolean;
@@ -6,7 +6,7 @@ interface AddTaskModalContextType {
   closeModal: () => void;
 }
 
-const AddTaskModalContext = createContext<AddTaskModalContextType | undefined>(undefined);
+export const AddTaskModalContext = createContext<AddTaskModalContextType | undefined>(undefined);
 
 export const useAddTaskModal = () => {
   const context = useContext(AddTaskModalContext);


### PR DESCRIPTION
This commit addresses several TypeScript errors that were causing the client build to fail:

- Exported `AddTaskModalContext` from `shared/contexts/AddTaskModalContext.tsx`.
- Removed unused `styles` import in `features/ColumnLane/ColumnLane.tsx`.
- Removed unused `React`, `useState`, and `ReactNode` imports from `shared/contexts/AddTaskModalContext.tsx`.

These changes allow the client project to build successfully.