### PR TITLE
Fix: Correct syntax for tags column in Liquibase changeset

### DIFF
--- a/api/db/changelog/db.changelog-0.2.xml
+++ b/api/db/changelog/db.changelog-0.2.xml
@@ -13,7 +13,7 @@
             <column name="priority" type="VARCHAR(255)"/>
         </addColumn>
         <addColumn tableName="tasks">
-            <column name="tags" type="VARCHAR(255)[]"/> <!-- Changed from TEXT[] -->
+            <column name="tags" type="TEXT[]"/> <!-- Changed from TEXT[] -->
         </addColumn>
         <!-- due_date is already expected to be in the table, if not, it should have been in an earlier migration.
              If it needs to be added now, uncomment and adjust:

--- a/api/db/changelog/db.changelog-0.2.xml
+++ b/api/db/changelog/db.changelog-0.2.xml
@@ -13,7 +13,7 @@
             <column name="priority" type="VARCHAR(255)"/>
         </addColumn>
         <addColumn tableName="tasks">
-            <column name="tags" type="TEXT[]"/> <!-- Changed from TEXT[] -->
+            <column name="tags" type="TEXT[]"/> <!-- Using TEXT[] for variable-length string array, avoids syntax issues with VARCHAR(n)[] in PostgreSQL -->
         </addColumn>
         <!-- due_date is already expected to be in the table, if not, it should have been in an earlier migration.
              If it needs to be added now, uncomment and adjust:


### PR DESCRIPTION
The previous definition for the 'tags' column, `VARCHAR(255)[]`, resulted in a PostgreSQL syntax error during database migration. This was because the length specifier `(255)` is not valid when defining an array of VARCHARs in this manner.

Changed the column type to `TEXT[]` to resolve the syntax error and align with common PostgreSQL practices for text arrays. This was also the original type before a previous modification.