### PR TITLE
Fix: Remove trailing backticks causing TS1160 error

### DIFF
--- a/client/src/features/TaskDetailModal/ui/EditableField.tsx
+++ b/client/src/features/TaskDetailModal/ui/EditableField.tsx
@@ -124,4 +124,3 @@ const EditableField: React.FC<EditableFieldProps> = ({
 };
 
 export default EditableField;
-```


### PR DESCRIPTION
I've removed three trailing backticks from the end of `client/src/features/TaskDetailModal/ui/EditableField.tsx`.

These invisible characters were causing the TypeScript compiler to erroneously report an "TS1160: Unterminated template literal" error at line 128 of the file, even though the file's actual code content was much shorter. I identified the trailing backticks and they were likely an accidental paste.

With this fix, the TS1160 error is resolved, allowing the build process to proceed further. A subsequent TypeScript error (TS2741) in a different file (`TaskDetailModal.tsx`) is now unmasked.