### PR TITLE
Fix: Add missing value prop to EditableField

### DIFF
--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.tsx
@@ -234,6 +234,7 @@ const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, isOpen, onClose
                   <>
                     <span>{task.humanReadableId}: </span> {/* Non-editable part */}
                     <EditableField
+                      value={task.title} // Add this line
                       editableValue={editableTitle}
                       isEditing={true}
                       isUpdating={isUpdatingTitle}


### PR DESCRIPTION
The EditableField component in TaskDetailModal was missing the required `value` prop, causing a TypeScript error during the build. This commit adds the `value` prop, passing `task.title` to ensure the component receives the necessary data.