### PR TITLE
Fix: Correct PostCSS parsing error in TaskDetailModal.module.css

### DIFF
--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
@@ -294,4 +294,3 @@ input:disabled, textarea:disabled {
   margin-top: calc(var(--spacing-base) * 2.5);
   align-self: flex-end;
 }
-```


### PR DESCRIPTION
The client build was failing with a PostCSS error: "[vite:css] [postcss] ... TaskDetailModal.module.css:297:1: Unknown word ``` ".

This was caused by extraneous characters at the end of the CSS file `client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css`.

I've corrected the file by removing these extraneous characters, ensuring it ends precisely after the final CSS rule's closing brace. The client build now completes successfully.