### PR TITLE
Fix: Adjust display of project title and task titles

### DIFF
--- a/client/src/features/TaskCard/TaskCard.tsx
+++ b/client/src/features/TaskCard/TaskCard.tsx
@@ -37,7 +37,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onTaskClick }) => {
       onClick={() => onTaskClick(task)}
     >
       <div className={styles.taskTitle}>
-        {task.humanReadableId}: {task.title}
+        {task.humanReadableId ? `${task.humanReadableId}: ` : ''}{task.title}
       </div>
       {task.description && (
         <div className={styles.taskDescription}>

--- a/client/src/pages/BoardPage.tsx
+++ b/client/src/pages/BoardPage.tsx
@@ -427,7 +427,7 @@ const BoardPage: React.FC = () => {
       >
         <div> {/* Main container for BoardPage content */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: '10px' }}>
-            <h1>{boardData.name} ({boardData.prefix})</h1>
+            <h1>{boardData.name} {boardData.prefix ? `(${boardData.prefix})` : ''}</h1>
             <button
               onClick={() => setIsMembersModalOpen(true)}
               style={{ padding: '8px 15px', cursor: 'pointer' }}


### PR DESCRIPTION
Project titles will no longer display empty parentheses if a project prefix is not set. Task titles will no longer display a leading colon if the human-readable task ID is not set.

These changes address your feedback regarding confusing extra characters in the UI.