### PR TITLE
Fix: Use type-only import for ThemeOption

### DIFF
--- a/client/src/pages/UserSettingsPage.tsx
+++ b/client/src/pages/UserSettingsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme, ThemeOption } from '../shared/contexts/ThemeContext';
+import { useTheme, type ThemeOption } from '../shared/contexts/ThemeContext';
 import styles from './UserSettingsPage.module.css'; // We'll create this CSS module next
 
 const themeOptionsConfig: { value: ThemeOption; label: string }[] = [


### PR DESCRIPTION
Resolves TypeScript error TS1484 caused by verbatimModuleSyntax by changing the import of `ThemeOption` in
`client/src/pages/UserSettingsPage.tsx` to a type-only import.