### PR TITLE
Fix: Apply dark theme to columns, tasks, and nav panel

### DIFF
--- a/client/src/app/styles/theme.css
+++ b/client/src/app/styles/theme.css
@@ -15,6 +15,45 @@
   --card-border-color: #e0e0e0;
   --modal-background-color: #ffffff;
   --modal-text-color: #000000;
+
+  /* Extended Semantic Variables */
+  --text-secondary-color: rgba(0, 0, 0, 0.7);
+  --text-tertiary-color: rgba(0, 0, 0, 0.5);
+  --text-placeholder-color: rgba(0, 0, 0, 0.4);
+  --text-disabled-color: rgba(0, 0, 0, 0.3);
+  --link-hover-color: #0056b3;
+
+  --element-hover-background-color: rgba(0, 0, 0, 0.03);
+  --background-subtle-color: #f8f9fa;
+  --border-subtle-color: #e9ecef;
+  --background-disabled-color: #e9ecef;
+
+  --input-background-color: #ffffff;
+  --input-border-color: #ced4da;
+  --input-text-color: #495057;
+
+  --danger-background-color: #dc3545;
+  --danger-background-subtle-color: #f8d7da;
+  --danger-text-color: #721c24;
+  --danger-border-color: #f5c6cb;
+
+  --success-background-color: #28a745;
+  --success-background-subtle-color: #d4edda;
+  --success-text-color: #155724;
+  --success-border-color: #c3e6cb;
+
+  --button-secondary-background-color: #6c757d;
+  --button-secondary-text-color: #ffffff;
+  --button-secondary-border-color: #6c757d;
+  --button-secondary-hover-background-color: #5a6268;
+
+  --button-disabled-background-color: #ced4da;
+  --button-disabled-text-color: #6c757d;
+
+  --tag-background-color: #e9ecef;
+  --tag-text-color: #495057;
+
+  --backdrop-color: rgba(0, 0, 0, 0.5);
 }
 
 /* Dark Theme Variables */
@@ -22,17 +61,56 @@
   --background-color: #121212;
   --text-color: #e0e0e0;
   --primary-color: #bb86fc;
-  --secondary-color: #03dac6;
+  --secondary-color: #03dac6; /* Accent color */
   --border-color: #333333;
   --link-color: #bb86fc;
-  --button-background-color: #bb86fc;
-  --button-text-color: #000000;
-  --button-hover-background-color: #3700b3;
+  --button-background-color: #bb86fc; /* Primary button */
+  --button-text-color: #000000;      /* Text on primary button */
+  --button-hover-background-color: #9e47f5; /* Darken primary button on hover */
   --header-background-color: #1e1e1e;
   --header-text-color: #e0e0e0;
   --card-background-color: #1e1e1e;
   --card-border-color: #444444;
   --modal-background-color: #1e1e1e;
   --modal-text-color: #e0e0e0;
-  --settings-page-h2-border-color: #555555; /* Added for UserSettingsPage */
+  --settings-page-h2-border-color: #555555; /* Specific for UserSettingsPage */
+
+  /* Extended Semantic Variables */
+  --text-secondary-color: rgba(224, 224, 224, 0.7);
+  --text-tertiary-color: rgba(224, 224, 224, 0.5);
+  --text-placeholder-color: rgba(224, 224, 224, 0.4);
+  --text-disabled-color: rgba(224, 224, 224, 0.3);
+  --link-hover-color: #d0a0ff;
+
+  --element-hover-background-color: rgba(255, 255, 255, 0.08);
+  --background-subtle-color: #2a2a2a;
+  --border-subtle-color: #2c2c2c;
+  --background-disabled-color: #2a2a2a;
+
+  --input-background-color: #2c2c2c;
+  --input-border-color: #555555;
+  --input-text-color: #e0e0e0;
+
+  --danger-background-color: #cf6679; /* Material Design Dark Theme Error Color */
+  --danger-background-subtle-color: rgba(207, 102, 121, 0.2);
+  --danger-text-color: #cf6679;
+  --danger-border-color: #cf6679;
+
+  --success-background-color: #03dac6; /* Using secondary as a stand-in for success accent */
+  --success-background-subtle-color: rgba(3, 218, 198, 0.2);
+  --success-text-color: #03dac6;
+  --success-border-color: #03dac6;
+
+  --button-secondary-background-color: #373737;
+  --button-secondary-text-color: #e0e0e0;
+  --button-secondary-border-color: #555555;
+  --button-secondary-hover-background-color: #4f4f4f;
+
+  --button-disabled-background-color: #2a2a2a;
+  --button-disabled-text-color: #555555;
+
+  --tag-background-color: #373737;
+  --tag-text-color: #e0e0e0;
+
+  --backdrop-color: rgba(0, 0, 0, 0.7);
 }

--- a/client/src/features/Comments/ui/AddCommentForm.module.css
+++ b/client/src/features/Comments/ui/AddCommentForm.module.css
@@ -6,16 +6,16 @@
   width: calc(100% - 22px); /* Full width minus padding/border */
   min-height: calc(var(--spacing-base) * 8); /* 64px */
   padding: calc(var(--spacing-base) * 1.5); /* 12px */
-  border: 1px solid var(--color-border); /* Was --color-border-neutral */
+  border: 1px solid var(--input-border-color);
   border-radius: var(--border-radius-medium); /* Use variable */
   margin-bottom: calc(var(--spacing-base) * 2); /* 16px */
-  background-color: var(--color-background-input);
-  color: var(--color-text-input);
+  background-color: var(--input-background-color);
+  color: var(--input-text-color);
 }
 /* Default focus style is now handled by global.css */
 /* Button styling is now handled by global .primary, .secondary, .danger classes */
 .errorText {
-  color: var(--color-text-danger);
+  color: var(--danger-text-color);
   font-size: 14px; /* Was 0.9em, consistent with caption size */
   margin-top: calc(var(--spacing-base) / 2); /* 4px */
 }

--- a/client/src/features/Comments/ui/CommentItem.module.css
+++ b/client/src/features/Comments/ui/CommentItem.module.css
@@ -1,23 +1,23 @@
 /* client/src/features/Comments/ui/CommentItem.module.css */
 .commentItem {
   padding: var(--spacing-base) 0;
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle-color);
 }
 .commentItem:last-child {
   border-bottom: none;
 }
 .commentAuthor {
   font-weight: bold;
-  color: var(--color-text-primary);
+  color: var(--text-color);
   margin-bottom: calc(var(--spacing-base) / 2); /* 4px */
 }
 .commentText {
   font-size: 0.95em;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color);
   white-space: pre-wrap; /* Preserve line breaks */
 }
 .commentTimestamp {
   font-size: 0.8em;
-  color: var(--color-text-tertiary);
+  color: var(--text-tertiary-color);
   margin-top: calc(var(--spacing-base) / 2); /* 4px */
 }

--- a/client/src/features/Notifications/ui/NotificationBell.module.css
+++ b/client/src/features/Notifications/ui/NotificationBell.module.css
@@ -6,14 +6,14 @@
 }
 .bellIcon { /* Basic representation, replace with actual SVG or font icon */
   font-size: 1.5em; /* Example size */
-  color: var(--color-icon-primary);
+  color: var(--text-color); /* Default icon color */
 }
 .unreadBadge {
   position: absolute;
   top: 0px;
   right: 0px;
-  background-color: var(--color-background-danger-strong);
-  color: var(--color-text-on-danger);
+  background-color: var(--danger-background-color);
+  color: var(--button-text-color); /* High contrast text for badge */
   border-radius: 50%;
   padding: 2px calc(var(--spacing-base) / 2); /* 2px 4px */
   font-size: 0.7em;

--- a/client/src/features/Notifications/ui/NotificationDropdown.module.css
+++ b/client/src/features/Notifications/ui/NotificationDropdown.module.css
@@ -6,27 +6,29 @@
   width: calc(var(--spacing-base) * 44); /* 352px, was 350px */
   max-height: calc(var(--spacing-base) * 50); /* 400px */
   overflow-y: auto;
-  background-color: var(--color-background-default);
-  border: 1px solid var(--color-border); /* Was --color-border-neutral */
+  background-color: var(--card-background-color); /* Dropdowns are card-like elements */
+  border: 1px solid var(--card-border-color);
   border-radius: var(--border-radius-small); /* 4px */
   box-shadow: var(--shadow-medium);
   z-index: 1100; /* Higher than other elements */
+  color: var(--text-color); /* Ensure default text color for dropdown content */
 }
 .dropdownHeader {
   padding: calc(var(--spacing-base) * 1.5); /* 12px, was 10px */
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid var(--color-border); /* Was --color-border-subtle */
+  border-bottom: 1px solid var(--border-subtle-color); /* Use subtle border for internal divisions */
 }
 .dropdownHeader h4 { margin: 0; }
 .markAllButton {
   font-size: 0.8em;
   padding: calc(var(--spacing-base) / 2) var(--spacing-base); /* 4px 8px */
   /* cursor: pointer; moved to global button style */
+  /* Assuming this will be a button styled with global classes like .button .secondary */
 }
 .noNotifications {
   padding: calc(var(--spacing-base) * 2.5); /* 20px */
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color);
 }

--- a/client/src/features/Notifications/ui/NotificationItem.module.css
+++ b/client/src/features/Notifications/ui/NotificationItem.module.css
@@ -1,26 +1,26 @@
 /* client/src/features/Notifications/ui/NotificationItem.module.css */
 .notificationItem {
   padding: calc(var(--spacing-base) * 1.5); /* 12px, was 10px */
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle-color);
   cursor: pointer;
-  background-color: var(--color-background-default);
+  background-color: transparent; /* Inherit from dropdown, or use card-background-color if items are distinct */
 }
 .notificationItem:last-child {
   border-bottom: none;
 }
 .notificationItem.unread {
-  background-color: var(--color-background-subtle); /* Slightly different background for unread */
-  font-weight: bold;
+  background-color: var(--background-subtle-color); /* Slightly different background for unread */
+  font-weight: bold; /* Keep bold for unread emphasis */
 }
 .notificationItem:hover {
-  background-color: var(--color-background-hover);
+  background-color: var(--element-hover-background-color);
 }
 .notificationText {
   font-size: 14px; /* Was 0.9em, consistent with caption size */
-  color: var(--color-text-primary);
+  color: var(--text-color); /* Main text color for notification content */
   margin-bottom: calc(var(--spacing-base) / 2); /* 4px */
 }
 .notificationTimestamp {
   font-size: 0.75em;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color);
 }

--- a/client/src/features/ProjectMembers/ui/ManageProjectMembersModal.module.css
+++ b/client/src/features/ProjectMembers/ui/ManageProjectMembersModal.module.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--color-backdrop);
+  background-color: var(--backdrop-color);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -13,7 +13,8 @@
 }
 
 .modalContent {
-  background-color: var(--color-background-element);
+  background-color: var(--modal-background-color);
+  color: var(--modal-text-color);
   padding: calc(var(--spacing-base) * 2.5); /* 20px */
   border-radius: var(--border-radius-large); /* 8px */
   min-width: calc(var(--spacing-base) * 50); /* 400px */
@@ -23,6 +24,7 @@
 
 .modalContent h2 {
   margin-top: 0;
+  color: var(--modal-text-color); /* Ensure heading uses modal text color */
 }
 
 .formGroup {
@@ -32,15 +34,16 @@
 .formGroup label {
   display: block;
   margin-bottom: calc(var(--spacing-base) / 2); /* 4px */
+  color: var(--modal-text-color); /* Or --text-secondary-color if labels are dimmer */
 }
 
 .formGroup input {
   width: calc(100% - 22px); /* Adjust for padding/border */
   padding: calc(var(--spacing-base) * 1.5); /* 12px */
-  border: 1px solid var(--color-border); /* Was --color-border-neutral */
+  border: 1px solid var(--input-border-color);
   border-radius: var(--border-radius-medium); /* Use variable */
-  background-color: var(--color-background-input);
-  color: var(--color-text-input);
+  background-color: var(--input-background-color);
+  color: var(--input-text-color);
 }
 /* Default focus style is now handled by global.css */
 
@@ -54,21 +57,27 @@
 }
 
 .errorText {
-  color: var(--color-text-danger);
+  color: var(--danger-text-color);
   font-size: 14px; /* Was 0.9em, consistent with caption size */
 }
 
 .memberList {
   list-style: none;
   padding: 0;
+  color: var(--modal-text-color); /* Ensure list text uses modal text color */
 }
 
 .memberItem {
   display: flex;
   justify-content: space-between;
+  align-items: center; /* Align items vertically */
   padding: var(--spacing-base) 0; /* 8px 0 */
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle-color);
 }
 .memberItem:last-child {
   border-bottom: none;
+}
+/* Text inside memberItem should also respect modal-text-color or its variants */
+.memberItem span { /* Basic example, might need more specific selectors */
+  color: var(--modal-text-color);
 }

--- a/client/src/features/TaskCard/TaskCard.module.css
+++ b/client/src/features/TaskCard/TaskCard.module.css
@@ -1,16 +1,19 @@
 .taskCard {
-  background-color: var(--color-background-element);
-  border: 1px solid var(--color-border);
+  background-color: var(--card-background-color);
+  border: 1px solid var(--card-border-color);
   border-radius: var(--border-radius-large); /* 8px */
   padding: var(--spacing-base); /* 8px */
   transition: all 0.2s ease-out;
   margin-bottom: var(--spacing-base); /* Add some margin between cards */
   cursor: grab; /* Indicate draggable */
+  color: var(--text-color); /* Ensure default text color is applied */
 }
 
 .taskCard:hover {
   box-shadow: var(--shadow-card-hover);
   transform: translateY(-2px);
+  /* Consider adding a subtle background change on hover if desired */
+  /* background-color: var(--element-hover-background-color); */
 }
 
 .taskCardDragging {
@@ -23,11 +26,12 @@
   font-size: 1rem; /* 16px */
   font-weight: 600;
   margin-bottom: calc(var(--spacing-base) / 2); /* 4px */
+  color: var(--text-color); /* Explicitly use main text color for titles */
 }
 
 .taskDescription {
   font-size: 0.875rem; /* 14px */
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color);
   margin-bottom: var(--spacing-base); /* 8px */
   /* Hide long descriptions, show more in modal */
   white-space: nowrap;
@@ -37,5 +41,5 @@
 
 .taskMeta {
   font-size: 0.75rem; /* 12px */
-  color: var(--color-text-tertiary);
+  color: var(--text-tertiary-color);
 }

--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
@@ -269,7 +269,6 @@ input:disabled, textarea:disabled {
 .buttonPrimary:disabled {
   background-color: var(--button-disabled-background-color);
   color: var(--button-disabled-text-color);
-  opacity: 0.7; /* Consider removing if disabled colors are sufficient */
   cursor: not-allowed;
 }
 .buttonSecondary {
@@ -285,7 +284,6 @@ input:disabled, textarea:disabled {
   background-color: var(--button-disabled-background-color);
   color: var(--button-disabled-text-color);
   border-color: var(--button-disabled-background-color); /* Or a specific disabled border */
-  opacity: 0.7; /* Consider removing if disabled colors are sufficient */
   cursor: not-allowed;
 }
 .buttonLink {

--- a/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
+++ b/client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css
@@ -1,12 +1,13 @@
 /* client/src/features/TaskDetailModal/ui/TaskDetailModal.module.css */
 .modalOverlay {
   position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-  background-color: var(--color-backdrop);
+  background-color: var(--backdrop-color);
   display: flex; justify-content: center; align-items: center;
   z-index: 1050;
 }
 .modalContent {
-  background-color: var(--color-background-element);
+  background-color: var(--modal-background-color);
+  color: var(--modal-text-color); /* Default text color for modal content */
   padding: calc(var(--spacing-base) * 3);
   border-radius: var(--border-radius-large);
   min-width: calc(var(--spacing-base) * 63); /* 504px */
@@ -20,11 +21,14 @@
 .taskDetails {
   /* Removed fixed margin-bottom, sections will handle their own */
 }
-.taskDetails h2 { margin-top: 0; }
+.taskDetails h2 {
+  margin-top: 0;
+  color: var(--modal-text-color); /* Ensure h2 uses modal text color */
+}
 /* .taskDetails p { white-space: pre-wrap; } Defined in .description specific styles */
 
 .commentsSection {
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-subtle-color); /* Use subtle border */
   padding-top: calc(var(--spacing-base) * 2);
   margin-top: calc(var(--spacing-base) * 2); /* Added margin-top for separation */
   overflow-y: auto;
@@ -35,7 +39,7 @@
 .editIcon {
   background: none;
   border: none;
-  color: var(--color-text-link);
+  color: var(--link-color);
   cursor: pointer;
   margin-left: var(--spacing-base-small); /* Reduced margin for "Edit" */
   font-size: 0.85em; /* Slightly smaller */
@@ -45,6 +49,7 @@
 }
 .editIcon:hover {
   text-decoration: underline;
+  color: var(--link-hover-color);
 }
 
 /* Shared styles for sections within taskDetails */
@@ -61,6 +66,7 @@
   justify-content: space-between;
   align-items: center;
   font-size: 1.8em;
+  color: var(--modal-text-color); /* Ensure this h2 also uses modal text color */
 }
 .taskHeader h2 .inlineEditSection { /* Specifically for title's edit mode form */
   flex-grow: 1; /* Allow the form to take space */
@@ -71,6 +77,7 @@
 .description {
   composes: taskDetailsSection;
   line-height: 1.6;
+  color: var(--modal-text-color); /* Description text */
 }
 .descriptionView {
   display: flex;
@@ -97,7 +104,7 @@
 }
 .metaGridItemLabel {
   font-weight: var(--font-weight-bold);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color); /* Use themed secondary text color */
   font-size: 0.9em;
 }
 .metaGridItemValueArea { /* Container for (value + edit button) in view mode for meta items */
@@ -111,6 +118,7 @@
 .metaGridItemValueText { /* Class for the actual text value span itself */
   flex-grow: 1; /* Allow text to take available space */
   word-break: break-word; /* Break long words if necessary */
+  color: var(--modal-text-color); /* Ensure value text uses modal text color */
 }
 
 
@@ -119,7 +127,7 @@
 }
 .tagsSectionLabel {
   font-weight: var(--font-weight-bold);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color); /* Use themed secondary text color */
   font-size: 0.9em;
   margin-bottom: var(--spacing-base-small);
   display: block;
@@ -139,8 +147,8 @@
   flex-grow: 1; /* Allow tags to take space */
 }
 .tagItem {
-  background-color: var(--color-background-tag);
-  color: var(--color-text-tag);
+  background-color: var(--tag-background-color);
+  color: var(--tag-text-color);
   padding: var(--spacing-base-small) var(--spacing-base);
   border-radius: var(--border-radius-medium);
   font-size: 0.9em;
@@ -151,12 +159,13 @@
 .editableFieldLabel { /* Default for label rendered by EditableField */
   display: block;
   font-weight: var(--font-weight-bold);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color); /* Use themed secondary text color */
   font-size: 0.9em;
   margin-bottom: var(--spacing-base-extra-small);
 }
 .editableFieldValueText { /* Default for value span rendered by EditableField */
   word-break: break-word;
+  color: var(--modal-text-color); /* Default value text */
 }
 .defaultValueArea { /* Default for container of (value + edit button) */
   display: flex;
@@ -203,11 +212,11 @@
 .formTextareaFull {
   width: 100%;
   padding: var(--spacing-base);
-  border: 1px solid var(--color-border-input);
+  border: 1px solid var(--input-border-color);
   border-radius: var(--border-radius-medium);
   box-sizing: border-box;
-  background-color: var(--color-background-input);
-  color: var(--color-text-input);
+  background-color: var(--input-background-color);
+  color: var(--input-text-color);
 }
 .formTextareaFull {
   min-height: 100px;
@@ -215,25 +224,26 @@
 }
 .formInput {
   padding: var(--spacing-base-small) var(--spacing-base);
-  border: 1px solid var(--color-border-input);
+  border: 1px solid var(--input-border-color);
   border-radius: var(--border-radius-medium);
   box-sizing: border-box;
-  background-color: var(--color-background-input);
-  color: var(--color-text-input);
+  background-color: var(--input-background-color);
+  color: var(--input-text-color);
 }
 input::placeholder, textarea::placeholder {
-  color: var(--color-text-placeholder);
+  color: var(--text-placeholder-color);
   opacity: 1;
 }
 input:disabled, textarea:disabled {
-  background-color: var(--color-background-disabled);
+  background-color: var(--background-disabled-color);
+  color: var(--text-disabled-color); /* Add disabled text color */
   cursor: not-allowed;
 }
 
 
 /* Error Messages */
 .errorTextSmall {
-  color: var(--color-text-error);
+  color: var(--danger-text-color);
   font-size: 0.85em;
   width: 100%;
 }
@@ -246,44 +256,49 @@ input:disabled, textarea:disabled {
   border-radius: var(--border-radius-medium);
   cursor: pointer;
   font-weight: var(--font-weight-bold);
-  transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out;
   text-align: center;
 }
 .buttonPrimary {
-  background-color: var(--color-button-primary-default);
-  color: var(--color-text-button-primary);
+  background-color: var(--button-background-color); /* Themed primary button */
+  color: var(--button-text-color);
 }
 .buttonPrimary:hover:not(:disabled) {
-  background-color: var(--color-button-primary-hover);
+  background-color: var(--button-hover-background-color);
 }
 .buttonPrimary:disabled {
-  background-color: var(--color-button-disabled);
-  opacity: 0.7;
+  background-color: var(--button-disabled-background-color);
+  color: var(--button-disabled-text-color);
+  opacity: 0.7; /* Consider removing if disabled colors are sufficient */
   cursor: not-allowed;
 }
 .buttonSecondary {
-  background-color: var(--color-button-secondary-default);
-  color: var(--color-text-button-secondary);
-  border: 1px solid var(--color-border-button-secondary);
+  background-color: var(--button-secondary-background-color);
+  color: var(--button-secondary-text-color);
+  border: 1px solid var(--button-secondary-border-color);
 }
 .buttonSecondary:hover:not(:disabled) {
-  background-color: var(--color-button-secondary-hover);
+  background-color: var(--button-secondary-hover-background-color);
+  /* border-color might also change on hover if desired */
 }
 .buttonSecondary:disabled {
-  background-color: var(--color-button-disabled);
-  opacity: 0.7;
+  background-color: var(--button-disabled-background-color);
+  color: var(--button-disabled-text-color);
+  border-color: var(--button-disabled-background-color); /* Or a specific disabled border */
+  opacity: 0.7; /* Consider removing if disabled colors are sufficient */
   cursor: not-allowed;
 }
 .buttonLink {
   background: none;
   border: none;
-  color: var(--color-text-link);
+  color: var(--link-color);
   text-decoration: none;
   padding: 0;
   font-weight: normal;
 }
 .buttonLink:hover {
   text-decoration: underline;
+  color: var(--link-hover-color);
 }
 .buttonSmall {
   padding: var(--spacing-base-small) var(--spacing-base);
@@ -302,7 +317,7 @@ input:disabled, textarea:disabled {
   align-items: center;
   margin-top: calc(var(--spacing-base) * 2.5);
   padding-top: calc(var(--spacing-base) * 1.5);
-  border-top: 1px solid var(--color-border); /* Optional: visual separation */
+  border-top: 1px solid var(--border-subtle-color); /* Optional: visual separation, use subtle */
 }
 
 /* Ensure the link within modalActions looks like a button if desired, or style as a link */
@@ -312,12 +327,13 @@ input:disabled, textarea:disabled {
   /* composes: button; */
   /* composes: buttonSecondary; */
   /* Or, if it's a true link, ensure it's styled appropriately */
-  color: var(--color-text-link);
+  color: var(--link-color); /* Use themed link color */
   text-decoration: none;
   padding: var(--spacing-base) 0; /* Adjust padding as needed */
 }
 .modalActions .buttonLink:hover {
   text-decoration: underline;
+  color: var(--link-hover-color); /* Use themed link hover color */
 }
 
 /* Style for the close button if it's inside modalActions */

--- a/client/src/features/authByEmail/ui/RegistrationForm.module.css
+++ b/client/src/features/authByEmail/ui/RegistrationForm.module.css
@@ -2,14 +2,15 @@
   max-width: calc(var(--spacing-base) * 50); /* 400px */
   margin: calc(var(--spacing-base) * 4) auto; /* 32px auto */
   padding: calc(var(--spacing-base) * 3); /* 24px */
-  background-color: var(--color-background-element);
+  background-color: var(--card-background-color); /* Forms are often card-like */
   border-radius: var(--border-radius-large); /* 8px */
   box-shadow: var(--shadow-medium);
+  color: var(--text-color); /* Default text color for form content */
 }
 
 .formContainer h2 {
   text-align: center;
-  color: var(--color-text-main);
+  color: var(--text-color); /* Main text color for heading */
   margin-bottom: calc(var(--spacing-base) * 3); /* 24px */
 }
 
@@ -20,24 +21,25 @@
 .formField label {
   display: block;
   margin-bottom: var(--spacing-base); /* 8px */
-  color: var(--color-text-secondary);
+  color: var(--text-secondary-color); /* Labels can use secondary text color */
   font-weight: 500;
 }
 
-/* Input fields will use global styles by default */
+/* Input fields will use global styles by default or can use --input-background-color etc. */
 /* We can add specific overrides here if needed */
 
 .submitButton {
   /* Use the global .primary button style by adding the class in JSX */
+  /* This button should use var(--button-background-color) and var(--button-text-color) via global styles */
   width: 100%;
   padding: calc(var(--spacing-base) * 1.5); /* 12px - larger for a primary action */
   font-weight: 600;
 }
 
 .errorMessage {
-  color: var(--color-error);
-  background-color: var(--color-background-danger-subtle); /* Light red background */
-  border: 1px solid var(--color-error);
+  color: var(--danger-text-color);
+  background-color: var(--danger-background-subtle-color);
+  border: 1px solid var(--danger-border-color);
   padding: calc(var(--spacing-base) * 1.5); /* 12px */
   border-radius: var(--border-radius-medium);
   margin-bottom: calc(var(--spacing-base) * 2); /* 16px */
@@ -45,9 +47,9 @@
 }
 
 .successMessage {
-  color: var(--color-success);
-  background-color: var(--color-background-success-subtle); /* Light green background */
-  border: 1px solid var(--color-success);
+  color: var(--success-text-color);
+  background-color: var(--success-background-subtle-color);
+  border: 1px solid var(--success-border-color);
   padding: calc(var(--spacing-base) * 1.5); /* 12px */
   border-radius: var(--border-radius-medium);
   margin-bottom: calc(var(--spacing-base) * 2); /* 16px */
@@ -57,4 +59,13 @@
 .registrationLinkContainer {
   text-align: center;
   margin-top: calc(var(--spacing-base) * 2); /* 16px, was 1rem */
+}
+/* Links inside this container should use var(--link-color) */
+.registrationLinkContainer a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+.registrationLinkContainer a:hover {
+  text-decoration: underline;
+  color: var(--link-hover-color);
 }

--- a/client/src/widgets/Header/Header.module.css
+++ b/client/src/widgets/Header/Header.module.css
@@ -1,7 +1,7 @@
 .header {
-  background-color: var(--color-background-element);
+  background-color: var(--header-background-color);
   padding: 0 calc(var(--spacing-base) * 3); /* 0 24px */
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-color);
   box-shadow: var(--shadow-sm);
 }
 
@@ -17,13 +17,13 @@
 .logo {
   font-size: 24px;
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--primary-color);
   text-decoration: none;
 }
 
 .logo:hover {
   text-decoration: none; /* Ensure no underline on hover for logo */
-  opacity: 0.85;
+  color: var(--link-hover-color); /* Use link hover color */
 }
 
 .navigation ul {
@@ -41,7 +41,7 @@
 .navigation a,
 .navigation button { /* For LogoutButton styling consistency */
   text-decoration: none;
-  color: var(--color-text-main);
+  color: var(--header-text-color); /* Use header specific text color */
   font-weight: 400;
   padding: calc(var(--spacing-base) * 0.5) calc(var(--spacing-base) * 1); /* 4px 8px */
   border-radius: var(--border-radius-medium); /* Using defined variable */
@@ -49,31 +49,34 @@
 }
 
 .navigation a:hover,
-.navigation button:hover {
-  color: var(--color-primary);
-  background-color: var(--color-primary-background-hover); /* Reinstated background hover */
+.navigation button:not(.secondary):hover { /* Apply hover to general buttons, not specifically styled secondary ones */
+  color: var(--link-hover-color); /* Use link hover color for text */
+  background-color: var(--element-hover-background-color); /* Subtle background for hover */
 }
 
 /* Style for active link if needed, requires NavLink from react-router-dom */
 .navigation a.active {
-  color: var(--color-primary);
+  color: var(--primary-color);
   font-weight: 700;
 }
 
 /* Ensure LogoutButton integrates well */
 .navigation button {
-  background-color: transparent;
+  background-color: transparent; /* Default for link-like buttons */
   border: none;
   cursor: pointer;
 }
 
-.navigation button.secondary { /* Targeting the LogoutButton's specific class if it has one */
-    color: var(--color-text-main); /* Default state */
-    border: 1px solid var(--color-border); /* Match other links better */
+/* Styling for a button that should look like a secondary action button */
+.navigation button.secondary {
+    color: var(--button-secondary-text-color);
+    background-color: var(--button-secondary-background-color);
+    border: 1px solid var(--button-secondary-border-color);
+    /* padding will be inherited from .navigation button */
 }
 
 .navigation button.secondary:hover {
-    color: var(--color-primary);
-    border-color: var(--color-primary);
-    background-color: var(--color-primary-background-hover); /* Reinstated background hover */
+    color: var(--button-secondary-text-color); /* Text color might not change or could be defined in theme */
+    background-color: var(--button-secondary-hover-background-color);
+    border-color: var(--button-secondary-hover-background-color); /* Or a specific hover border color */
 }

--- a/client/src/widgets/Layout/MainLayout.module.css
+++ b/client/src/widgets/Layout/MainLayout.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background-color: var(--color-background-page);
+  background-color: var(--background-color);
 }
 
 .mainContent {
@@ -20,9 +20,10 @@
 .footer {
   padding: calc(var(--spacing-base) * 2) calc(var(--spacing-base) * 3); /* 16px 24px */
   text-align: center;
-  background-color: var(--color-background-element);
-  border-top: 1px solid var(--color-border);
-  /* color and font-size moved to .text-caption utility class to be applied in TSX */
+  background-color: var(--card-background-color); /* Using card background for footer area */
+  border-top: 1px solid var(--border-color);
+  color: var(--text-secondary-color); /* Footer text can be secondary */
+  /* font-size moved to .text-caption utility class to be applied in TSX */
 }
 
 .footer p {


### PR DESCRIPTION
The columns, task cards, and navigation panel were previously not respecting the dark theme settings and appeared in light colors.

This commit addresses the issue by:
1. Auditing CSS modules for incorrect or missing theme variables.
2. Adding a comprehensive set of semantic CSS variables to `client/src/app/styles/theme.css` for both light and dark themes. This includes variables for text shades, backgrounds (default, subtle, disabled, input), borders (default, subtle, input), states (danger, success), buttons (secondary, disabled), tags, and backdrop.
3. Updating all relevant CSS modules in `client/src/features/` and `client/src/widgets/` to use these new theme variables.

This ensures that these components now correctly display in dark theme when it is enabled, and also maintains correct styling in light theme.