### PR TITLE
Fix: Resolve TypeScript and missing module errors during build

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.3.10",
         "@nestjs/platform-socket.io": "^10.3.10",
+        "@nestjs/swagger": "^7.4.0",
         "@nestjs/websockets": "^10.3.10",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -1395,6 +1396,12 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.9.tgz",
@@ -1598,6 +1605,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
@@ -1671,6 +1698,39 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.19",
@@ -2664,7 +2724,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -6065,7 +6124,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8446,6 +8504,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -33,7 +33,8 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.12.0",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.7.5",
+    "@nestjs/swagger": "^7.4.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.2",

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -14,6 +14,14 @@ import { TasksService } from '../tasks/tasks.service'; // Предполагае
 const DEFAULT_PROJECT_STATUSES = ['To Do', 'In Progress', 'Done'];
 const DEFAULT_PROJECT_TYPES = ['Task', 'Bug', 'Feature'];
 
+// Определим тип для ответа методов get/updateProjectSettings, соответствующий ProjectSettingsResponse на клиенте
+export interface ProjectSettingsDTO {
+  id: number;
+  name: string;
+  prefix: string;
+  settings_statuses: string[];
+  settings_types: string[];
+}
 
 @Injectable()
 export class ProjectsService {
@@ -138,17 +146,6 @@ export class ProjectsService {
     };
   }
 
-// Определим тип для ответа методов get/updateProjectSettings, соответствующий ProjectSettingsResponse на клиенте
-export interface ProjectSettingsDTO {
-  id: number;
-  name: string;
-  prefix: string;
-  settings_statuses: string[];
-  settings_types: string[];
-}
-
-// ... остальной код сервиса ...
-
   async getProjectSettings(projectId: number, userId: string): Promise<ProjectSettingsDTO> {
     const project = await this.ensureUserHasAccessToProject(projectId, userId);
     // Возвращаем только нужные поля для настроек, маппим task_prefix -> prefix
@@ -156,8 +153,8 @@ export interface ProjectSettingsDTO {
       id: project.id,
       name: project.name,
       prefix: project.task_prefix, // Маппинг
-      settings_statuses: project.settings_statuses as string[], // ensureUserHasAccessToProject уже распарсил
-      settings_types: project.settings_types as string[],   // ensureUserHasAccessToProject уже распарсил
+      settings_statuses: project.settings_statuses as unknown as string[], // ensureUserHasAccessToProject уже распарсил
+      settings_types: project.settings_types as unknown as string[],   // ensureUserHasAccessToProject уже распарсил
     };
   }
 
@@ -219,8 +216,8 @@ export interface ProjectSettingsDTO {
         id: parsedUpdatedProject.id,
         name: parsedUpdatedProject.name,
         prefix: parsedUpdatedProject.task_prefix, // Маппинг
-        settings_statuses: parsedUpdatedProject.settings_statuses as string[],
-        settings_types: parsedUpdatedProject.settings_types as string[],
+        settings_statuses: parsedUpdatedProject.settings_statuses as unknown as string[],
+        settings_types: parsedUpdatedProject.settings_types as unknown as string[],
       };
     });
   }

--- a/api/src/types/db-records.d.ts
+++ b/api/src/types/db-records.d.ts
@@ -24,6 +24,11 @@ export interface ProjectRecord {
   // parsed_settings_types?: string[];
 }
 
+export interface ParsedProjectRecord extends Omit<ProjectRecord, 'settings_statuses' | 'settings_types'> {
+  settings_statuses: string[];
+  settings_types: string[];
+}
+
 export interface ColumnRecord {
   id: string; // UUID
   name: string;


### PR DESCRIPTION
- Added @nestjs/swagger dependency to resolve module not found errors.
- Moved ProjectSettingsDTO interface out of ProjectsService class in projects.service.ts to fix syntax errors.
- Updated type assertions for settings_statuses and settings_types in projects.service.ts to use `as unknown as string[]` to correctly reflect the data type after parsing from JSON, resolving TypeScript conversion errors.

These changes allow the API to build successfully.