### PR TITLE
Fix: Resolve TypeScript errors in client build

### DIFF
--- a/client/src/pages/ProjectSettingsPage.tsx
+++ b/client/src/pages/ProjectSettingsPage.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { projectService } from '../shared/api/projectService';
-import { ProjectSettingsResponse, UpdateProjectSettingsPayload } from '../shared/api/types';
+import type { ProjectSettingsResponse, UpdateProjectSettingsPayload } from '../shared/api/types';
 import styles from './ProjectSettingsPage.module.css';
 // Assuming a shared Button and Input component exists, otherwise use native ones
 // import Button from '../shared/ui/Button/Button';

--- a/client/src/shared/api/projectService.ts
+++ b/client/src/shared/api/projectService.ts
@@ -1,6 +1,6 @@
 // Assuming an axios instance is configured, e.g., client/src/shared/api/axiosInstance.ts
 import apiClient from './axiosInstance'; // Using axiosInstance.ts as seen from ls
-import { ProjectSettingsResponse, UpdateProjectSettingsPayload } from './types';
+import type { ProjectSettingsResponse, UpdateProjectSettingsPayload } from './types';
 
 // Define interfaces for DTOs based on backend DTOs
 // These should ideally be in a shared types folder or generated from backend schema


### PR DESCRIPTION
- Removed unused `useCallback` import in `ProjectSettingsPage.tsx`.
- Updated imports in `ProjectSettingsPage.tsx` and `projectService.ts` to use type-only imports for `ProjectSettingsResponse` and `UpdateProjectSettingsPayload` as required by `verbatimModuleSyntax`.