### PR TITLE
Fix: Add default value for project settings columns

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@
     WORKDIR /usr/src/app
     
     COPY package*.json ./
-    RUN npm install
+    RUN npm cache clean --force && npm install
     COPY . .
     RUN npm run build
     
@@ -33,7 +33,7 @@
     WORKDIR /usr/src/app
     
     COPY package*.json ./
-    RUN npm install --omit=dev
+    RUN npm cache clean --force && npm install --omit=dev
     
     COPY --from=builder /usr/src/app/dist ./dist
     # Копируем и knexfile, и папку с миграциями Liquibase

--- a/api/db/changelog/db.changelog-0.3.xml
+++ b/api/db/changelog/db.changelog-0.3.xml
@@ -10,13 +10,13 @@
              as per db.changelog-0.1.xml. No action needed for task_prefix here. -->
 
         <addColumn tableName="projects">
-            <column name="settings_statuses" type="JSONB">
+            <column name="settings_statuses" type="JSONB" defaultValue="[]">
                 <constraints nullable="false"/>
                 <!-- Default values are now handled by application logic on project creation -->
             </column>
         </addColumn>
         <addColumn tableName="projects">
-            <column name="settings_types" type="JSONB">
+            <column name="settings_types" type="JSONB" defaultValue="[]">
                 <constraints nullable="false"/>
                 <!-- Default values are now handled by application logic on project creation -->
             </column>


### PR DESCRIPTION
- Added defaultValue="[]" to settings_statuses and settings_types columns in the Liquibase changeset to prevent errors when applying to tables with existing data.
- Added .dockerignore for the api service to reduce build context size.
- Added npm cache clean --force to Dockerfile for api service to potentially reduce disk usage during build.

Note: Full verification of the Liquibase migration was prevented by disk space limitations in the build environment.